### PR TITLE
Fix to close remainig popover after deleting table

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -104,6 +104,7 @@ export default function Table(props) {
                   }}
                 />
                 <Popover
+                  key={tableData.key}
                   content={
                     <div className="popover-theme">
                       <div className="mb-2">

--- a/src/context/TablesContext.jsx
+++ b/src/context/TablesContext.jsx
@@ -45,6 +45,7 @@ export default function TablesContextProvider({ children }) {
           comment: "",
           indices: [],
           color: defaultBlue,
+          key: Date.now(),
         },
       ]);
     }


### PR DESCRIPTION
## Steps to reproduce
1. Add multiple tables
2. Click a table
3. Click tertiary icon to show the popover
4. Delete the first created table

**Expected**
The popover should be hidden

**Actual**
The popover is visible

## Describe your changes
The change fixes to hide `Popover` in `Table.jsx`, because the component remains open after deleting an existing table. The approach is to assign unique key to each table and assign it to the component's key. 

