### PR TITLE
Fix to boolean default values not displayed

### DIFF
--- a/src/utils/astToDiagram.js
+++ b/src/utils/astToDiagram.js
@@ -31,7 +31,7 @@ export function astToDiagram(ast) {
             field.primary = false;
             if (d.primary_key) field.primary = true;
             field.default = "";
-            if (d.default_val) field.default = d.default_val.value.value;
+            if (d.default_val) field.default = d.default_val.value.value.toString();
             if (d.definition["length"]) field.size = d.definition["length"];
             field.check = "";
             if (d.check) {


### PR DESCRIPTION
Fix to issue #9.
The value of the `default` field of a Table must be a String, but `astToDiagram.js` was setting a Boolean value.
I simply enforced the value to be a String by calling the `toString()` method.

With the fix, the default value is correctly displayed in the editor and it's correctly exported.