### PR TITLE
Fix to comments visualization in tables and fields popovers

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -168,7 +168,7 @@ export default function Table(props) {
                   position="rightTop"
                   showArrow
                   trigger="click"
-                  style={{ width: "200px" }}
+                  style={{ width: "200px", wordBreak: "break-word" }}
                 >
                   <Button
                     icon={<IconMore />}
@@ -219,10 +219,19 @@ export default function Table(props) {
                       <strong>Default :</strong>{" "}
                       {e.default === "" ? "Not set" : e.default}
                     </p>
+                    <p>
+                      <strong>Comment:</strong>{" "}
+                      {e.comment === "" ? (
+                        "Not comment" 
+                      ) : (
+                        <div>{e.comment}</div>
+                      )}
+                    </p>
                   </div>
                 }
                 position="right"
                 showArrow
+                style={{ width: "200px", wordBreak: "break-word" }}
               >
                 {field(e, i)}
               </Popover>

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -223,16 +223,15 @@ export default function Table(props) {
                     <p>
                       <strong>Comment:</strong>{" "}
                       {e.comment === "" ? (
-                        "Not comment" 
+                        "No comment" 
                       ) : (
-                        <div>{e.comment}</div>
+                        <div style={{ maxWidth: "260px", wordBreak: "break-word" }}>{e.comment}</div>
                       )}
                     </p>
                   </div>
                 }
                 position="right"
                 showArrow
-                style={{ width: "200px", wordBreak: "break-word" }}
               >
                 {field(e, i)}
               </Popover>


### PR DESCRIPTION
I saw issue #26 and I didn't catch what it was refering to (maybe some about bringing comments from SQL code?), but I found out a few bugs in comments display while you hover the mouse over tables and tables' fields.

- If a word in a table comment (in the SidePanel) was too long, it would get out of the popover. I fixed it by adding `wordBreak:"break-word"` to the Popover's style property.
- While hovering a field in any table, it would display all its properties except for its comment, so I added it below "Default" section, adding the word-breaking fix too.

This is not a big deal but it would be my first contribution ever, so I hope it helps.