### PR TITLE
Fixed field circle icons not moving in Safari

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -99,7 +99,7 @@ export default function Table(props) {
                   size="small"
                   theme="solid"
                   style={{
-                    backgroundColor: "#2f68ad",
+                    backgroundColor: "#2f68adb3",
                     marginRight: "6px",
                   }}
                   onClick={openEditor}
@@ -174,7 +174,7 @@ export default function Table(props) {
                     type="tertiary"
                     size="small"
                     style={{
-                      backgroundColor: "grey",
+                      backgroundColor: "#808080b3",
                       color: "white",
                     }}
                   />
@@ -277,7 +277,7 @@ export default function Table(props) {
           } flex items-center gap-2 overflow-hidden`}
         >
           <button
-            className="flex-shrink-0 w-[10px] h-[10px] bg-[#2f68ad] rounded-full"
+            className="flex-shrink-0 w-[10px] h-[10px] bg-[#2f68adcc] rounded-full"
             onMouseDown={() => {
               handleGripField(index);
               setLinkingLine((prev) => ({
@@ -301,7 +301,7 @@ export default function Table(props) {
               theme="solid"
               size="small"
               style={{
-                backgroundColor: "#d42020",
+                backgroundColor: "#d42020b3",
               }}
               icon={<IconMinus />}
               onClick={() => deleteField(fieldData, tableData.id)}

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -53,7 +53,7 @@ export default function Table(props) {
         .getElementById(`scroll_table_${tableData.id}`)
         .scrollIntoView({ behavior: "smooth" });
     }
-  }
+  };
 
   return (
     <>
@@ -100,7 +100,6 @@ export default function Table(props) {
                   theme="solid"
                   style={{
                     backgroundColor: "#2f68ad",
-                    opacity: "0.7",
                     marginRight: "6px",
                   }}
                   onClick={openEditor}
@@ -175,7 +174,6 @@ export default function Table(props) {
                     type="tertiary"
                     size="small"
                     style={{
-                      opacity: "0.7",
                       backgroundColor: "grey",
                       color: "white",
                     }}
@@ -279,7 +277,7 @@ export default function Table(props) {
           } flex items-center gap-2 overflow-hidden`}
         >
           <button
-            className="flex-shrink-0 w-[10px] h-[10px] bg-[#2f68ad] opacity-80 z-50 rounded-full"
+            className="flex-shrink-0 w-[10px] h-[10px] bg-[#2f68ad] rounded-full"
             onMouseDown={() => {
               handleGripField(index);
               setLinkingLine((prev) => ({
@@ -303,7 +301,6 @@ export default function Table(props) {
               theme="solid"
               size="small"
               style={{
-                opacity: "0.7",
                 backgroundColor: "#d42020",
               }}
               icon={<IconMinus />}

--- a/src/components/SimpleCanvas.jsx
+++ b/src/components/SimpleCanvas.jsx
@@ -41,7 +41,7 @@ function Table({ table, grab }) {
           >
             <div className={hoveredField === i ? "text-zinc-500" : ""}>
               <button
-                className={`w-[9px] h-[9px] bg-[#2f68ad] rounded-full me-2`}
+                className={`w-[9px] h-[9px] bg-[#2f68adcc] rounded-full me-2`}
               />
               {e.name}
             </div>

--- a/src/components/SimpleCanvas.jsx
+++ b/src/components/SimpleCanvas.jsx
@@ -41,7 +41,7 @@ function Table({ table, grab }) {
           >
             <div className={hoveredField === i ? "text-zinc-500" : ""}>
               <button
-                className={`w-[9px] h-[9px] bg-[#2f68ad] opacity-80 z-50 rounded-full me-2`}
+                className={`w-[9px] h-[9px] bg-[#2f68ad] rounded-full me-2`}
               />
               {e.name}
             </div>
@@ -161,8 +161,8 @@ export default function SimpleCanvas({ diagram, zoom }) {
       const dy = e.clientY - offset.y;
       setTables((prev) =>
         prev.map((table, i) =>
-          i === dragging ? { ...table, x: dx, y: dy } : table
-        )
+          i === dragging ? { ...table, x: dx, y: dy } : table,
+        ),
       );
     }
   };

--- a/src/components/Thumbnail.jsx
+++ b/src/components/Thumbnail.jsx
@@ -116,7 +116,7 @@ export default function Thumbnail({ diagram, i, zoom, theme }) {
                     >
                       <div className="flex items-center justify-start">
                         <div
-                          className={`w-[6px] h-[6px] bg-[#2f68ad] opacity-80 z-50 rounded-full me-2`}
+                          className={`w-[6px] h-[6px] bg-[#2f68adcc] rounded-full me-2`}
                         ></div>
                         <div>{f.name}</div>
                       </div>


### PR DESCRIPTION
Fix to #32. 
For some reason, the problem seems to be related to the opacity of the buttons. I fixed it by setting the opacity back to 1, which doesn't seem to ruin the UX.