### PR TITLE
Fix class name evaluated by short circuit

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -53,7 +53,7 @@ export default function Table(props) {
         .getElementById(`scroll_table_${tableData.id}`)
         .scrollIntoView({ behavior: "smooth" });
     }
-  }
+  };
 
   return (
     <>
@@ -260,7 +260,9 @@ export default function Table(props) {
     return (
       <div
         className={`${
-          index === tableData.fields.length - 1 || "border-b border-gray-400"
+          index === tableData.fields.length - 1
+            ? ""
+            : "border-b border-gray-400"
         } group h-[36px] px-2 py-1 flex justify-between items-center gap-1 w-full overflow-hidden`}
         onMouseEnter={() => {
           setHoveredField(index);


### PR DESCRIPTION
## Steps to reproduce
1. Add multiple tables
2. Open DevTools
3. Check the class name of the last table

**Expected**
The class name should not contain `true`

**Actual**
The class name contains `true`

## Describe your changes
As the short-circuit evaluation is used inside backtick, it converts the boolean value to string when the expression is true. Instead, the ternary operation is used as a fix. When the condition is true, it will return an empty string.