### PR TITLE
Fix rendering buttons in table in safari

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -100,8 +100,7 @@ export default function Table(props) {
                   size="small"
                   theme="solid"
                   style={{
-                    backgroundColor: "#2f68ad",
-                    opacity: "0.7",
+                    backgroundColor: "#2F68ADB3",
                     marginRight: "6px",
                   }}
                   onClick={openEditor}
@@ -176,8 +175,7 @@ export default function Table(props) {
                     type="tertiary"
                     size="small"
                     style={{
-                      opacity: "0.7",
-                      backgroundColor: "grey",
+                      backgroundColor: "#808080B3",
                       color: "white",
                     }}
                   />
@@ -282,7 +280,7 @@ export default function Table(props) {
           } flex items-center gap-2 overflow-hidden`}
         >
           <button
-            className="flex-shrink-0 w-[10px] h-[10px] bg-[#2f68ad] opacity-80 z-50 rounded-full"
+            className="flex-shrink-0 w-[10px] h-[10px] bg-[#2F68ADCC] rounded-full"
             onMouseDown={() => {
               handleGripField(index);
               setLinkingLine((prev) => ({
@@ -316,8 +314,7 @@ export default function Table(props) {
               theme="solid"
               size="small"
               style={{
-                opacity: "0.7",
-                backgroundColor: "#d42020",
+                backgroundColor: "#D42020B3",
               }}
               icon={<IconMinus />}
               onClick={() => deleteField(fieldData, tableData.id)}

--- a/src/components/SimpleCanvas.jsx
+++ b/src/components/SimpleCanvas.jsx
@@ -51,7 +51,7 @@ function Table({ table, grab }) {
           >
             <div className={hoveredField === i ? "text-zinc-500" : ""}>
               <button
-                className={`w-[9px] h-[9px] bg-[#2f68ad] opacity-80 z-50 rounded-full me-2`}
+                className={`w-[9px] h-[9px] bg-[#2F68ADCC] rounded-full me-2`}
               />
               {e.name}
             </div>


### PR DESCRIPTION
## Steps to reproduce
1. Open Safari

**- Landing Page**
2. Check the position of the circle icon next to each field in a table

**- Try it yourself Page**
2. Add multiple tables
3. Check the position of the circle icon next to each field in a table
4. Hover the field or title
5. Check the position of buttons

**Expected**
It should render on the right position

**Actual**
It renders on different position

## Describe your changes
In Safari, applying opacity and z-index to an element within an SVG element can significantly impact its position. It's advisable to avoid directly setting opacity and instead adjust the alpha value of the background-color property. Additionally, the behaviour of z-index can be inconsistent; for instance, an icon may remain visible above another table even when that table is hidden beneath another table. Accordingly, z-index is removed as well.

## Notes
This includes the same fix as #35 but also additional fix to render buttons in the right position 