### PR TITLE
Open note in tab after clicking edit button

### DIFF
--- a/src/components/EditorCanvas/Note.jsx
+++ b/src/components/EditorCanvas/Note.jsx
@@ -61,22 +61,18 @@ export default function Note({ data, onMouseDown }) {
   };
 
   const edit = () => {
-    if (layout.sidebar) {
-      setSelectedElement((prev) => ({
-        ...prev,
-        currentTab: Tab.NOTES,
-      }));
-      if (selectedElement.currentTab !== Tab.NOTES) return;
+    setSelectedElement((prev) => ({
+      ...prev,
+      ...(layout.sidebar && { currentTab: Tab.NOTES }),
+      ...(!layout.sidebar && { element: ObjectType.NOTE }),
+      id: data.id,
+      open: true,
+    }));
+
+    if (layout.sidebar && selectedElement.currentTab === Tab.NOTES) {
       document
         .getElementById(`scroll_note_${data.id}`)
         .scrollIntoView({ behavior: "smooth" });
-    } else {
-      setSelectedElement((prev) => ({
-        ...prev,
-        element: ObjectType.NOTE,
-        id: data.id,
-        open: true,
-      }));
     }
   };
 

--- a/src/components/EditorSidePanel/NotesTab/NotesTab.jsx
+++ b/src/components/EditorSidePanel/NotesTab/NotesTab.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Row, Col, Button, Collapse } from "@douyinfe/semi-ui";
 import { IconPlus } from "@douyinfe/semi-icons";
 import { useNotes, useSelect } from "../../../hooks";

--- a/src/components/EditorSidePanel/NotesTab/NotesTab.jsx
+++ b/src/components/EditorSidePanel/NotesTab/NotesTab.jsx
@@ -1,20 +1,27 @@
 import { useState } from "react";
 import { Row, Col, Button, Collapse } from "@douyinfe/semi-ui";
 import { IconPlus } from "@douyinfe/semi-icons";
-import { useNotes } from "../../../hooks";
+import { useNotes, useSelect } from "../../../hooks";
 import Empty from "../Empty";
 import SearchBar from "./SearchBar";
 import NoteInfo from "./NoteInfo";
 
 export default function NotesTab() {
   const { notes, addNote } = useNotes();
-  const [activeKey, setActiveKey] = useState("");
+  const { selectedElement, setSelectedElement } = useSelect();
 
   return (
     <>
       <Row gutter={6}>
         <Col span={16}>
-          <SearchBar setActiveKey={setActiveKey} />
+          <SearchBar
+            setActiveKey={(activeKey) =>
+              setSelectedElement((prev) => ({
+                ...prev,
+                id: parseInt(activeKey),
+              }))
+            }
+          />
         </Col>
         <Col span={8}>
           <Button icon={<IconPlus />} block onClick={() => addNote()}>
@@ -26,8 +33,14 @@ export default function NotesTab() {
         <Empty title="No text notes" text="Add notes cuz why not!" />
       ) : (
         <Collapse
-          activeKey={activeKey}
-          onChange={(k) => setActiveKey(k)}
+          activeKey={selectedElement.open ? `${selectedElement.id}` : ""}
+          onChange={(activeKey) => {
+            setSelectedElement((prev) => ({
+              ...prev,
+              id: parseInt(activeKey),
+              open: true,
+            }));
+          }}
           accordion
         >
           {notes.map((n, i) => (


### PR DESCRIPTION
## Describe your changes
The new enhancement is implemented for the edit button in a note, when the sidebar is open. The UX is the same as how it works in the edit button for a table. When the edit button is clicked in a note, the note tab is open and the selected note will be open as well.