### PR TITLE
Fix to show the state of field summary in setting

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1024,7 +1024,7 @@ export default function ControlPanel({
         },
       },
       "Field details": {
-        state: layout.showFieldSummary ? "on" : "off",
+        state: settings.showFieldSummary ? "on" : "off",
         function: viewFieldSummary,
         shortcut: "Ctrl+Shift+F",
       },


### PR DESCRIPTION
## Steps to reproduce
1. Go to Try it for yourself 
2. Click View on the top menu
3. Click Field Details

**Expected**
It should show the right state of the setting

**Actual**
It is always off

## Describe your changes
The fix is to use the right state.