### PR TITLE
add docker build and push to container registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
@@ -26,4 +33,5 @@ jobs:
       with:
         push: true
         tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+        platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,8 +14,8 @@ jobs:
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: jpberno
-        password: dckr_pat_-5mmdsAWDh8DHZsJfZ4lN9d3Qew
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Build and push
       uses: docker/build-push-action@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "*"
 
+concurrency:
+  group: "docker-image"
+  cancel-in-progress: false
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+name: Docker Build and Push
+
+on:
+  push:
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        username: jpberno
+        password: dckr_pat_-5mmdsAWDh8DHZsJfZ4lN9d3Qew
+    
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        tags: jpberno/test-drawdb:latest #ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,5 +21,5 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         push: true
-        tags: jpberno/test-drawdb:latest #ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+        tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      uses: docker/login-action@v3
       with:
         username: jpberno
         password: dckr_pat_-5mmdsAWDh8DHZsJfZ4lN9d3Qew

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,10 +4,6 @@ on:
   push:
     tags:
       - "*"
-  pull_request:
-    branches:
-      - main
-
 
 jobs:
   docker:


### PR DESCRIPTION
Adds GitHub Actions workflow that builds and push a docker image to ghcr.io container registry.
- workflow is triggered on a new tag being pushed in the repository
- image is tagged with two tags: `:versionTag` and `:latest`

Requires initial setup of GitHub Container Registry or Dockerhub from repository mainteners

closes #11 