### PR TITLE
Update opacity style when an item is being hover after another item is dragged over

### DIFF
--- a/src/components/EditorSidePanel/TablesTab/TableInfo.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableInfo.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import {
   Collapse,
   Row,


### PR DESCRIPTION
## Describe your changes

The new enhancement is to update the style of opacity for an item, which is hover after another item is dragged among the list of table fields. 