### PR TITLE
ClickHouse Export

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -30,6 +30,7 @@ import {
   jsonToSQLite,
   jsonToMariaDB,
   jsonToSQLServer,
+  jsonToClickHouse
 } from "../../utils/toSQL";
 import {
   ObjectType,
@@ -922,6 +923,21 @@ export default function ControlPanel({
             MSSQL: () => {
               setModal(MODAL.CODE);
               const src = jsonToSQLServer({
+                tables: tables,
+                references: relationships,
+                types: types,
+              });
+              setExportData((prev) => ({
+                ...prev,
+                data: src,
+                extension: "sql",
+              }));
+            },
+          },
+          {
+            ClickHouse: () => {
+              setModal(MODAL.CODE);
+              const src = jsonToClickHouse({
                 tables: tables,
                 references: relationships,
                 types: types,

--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -42,6 +42,7 @@ export default function TableField({ data, tid, index }) {
       </Col>
       <Col span={8}>
         <Select
+          allowCreate={true}
           className="w-full"
           optionList={[
             ...sqlDataTypes.map((value) => ({

--- a/src/components/EditorSidePanel/TypesTab/TypeField.jsx
+++ b/src/components/EditorSidePanel/TypesTab/TypeField.jsx
@@ -55,6 +55,7 @@ export default function TypeField({ data, tid, fid }) {
       <Col span={11}>
         <Select
           className="w-full"
+          
           optionList={[
             ...sqlDataTypes.map((value) => ({
               label: value,


### PR DESCRIPTION
- Basic export for Clickhouse SQL supporting primary key/order by and Nullable fields
- Added the possibility to specify a custom Data Type for a table field. (The `<Select/>` of the type is now open to custom user inputs, to evaluate if this is useful to other DB Engines)

### To Do
Allow in the UI to select a specific flavour of DB Engine for a specific document, in this way we can show or hide fields or table configurations in the UI. Eg. On ClickHouse a table could support multiple Engine so there should be a way in the UI to specify that configuration on the table object. Or for example hide the "Types" tab in the UI since Clickhouse don't support those.