### PR TITLE
feat: add Docker Compose 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,16 @@
+services:
+  drawdb:
+    image: node:20-alpine
+    container_name: drawdb
+    ports:
+      - 5173:5173
+    working_dir: /var/www/html
+    volumes:
+      - ./:/var/www/html
+    command: sh -c "npm install && npm run dev:docker"
+    networks:
+      - default
+
+networks:
+  default:
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:docker": "vite --host",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"


### PR DESCRIPTION
Added `compose.yml` to use Docker Compose when running the project in a development environment.
To use, simply run `docker compose up` or `docker compose up -d` to run and detach console


Created the script "dev:docker" to run vite with --host option, exposing the port to outside the container