### PR TITLE
Fix: load name of lastest modified diagram

### DIFF
--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -131,6 +131,7 @@ export default function WorkSpace() {
         .then((d) => {
           if (d) {
             setId(d.id);
+            setTitle(d.name);
             setTables(d.tables);
             setRelationships(d.references);
             setNotes(d.notes);


### PR DESCRIPTION
I have fixed a bug with the following steps:

1. I renamed the diagram and saved it.
2. I closed the browser and reopened it.
3. The renamed name was not reloaded.

Please review PR.
Thank you very much.