### PR TITLE
feat: add color for table info

### DIFF
--- a/src/components/EditorSidePanel/NotesTab/NoteInfo.jsx
+++ b/src/components/EditorSidePanel/NotesTab/NoteInfo.jsx
@@ -98,7 +98,7 @@ export default function NoteInfo({ data, nid }) {
                     <button
                       key={c}
                       style={{ backgroundColor: c }}
-                      className="p-3 rounded-full mx-1"
+                      className="w-10 h-10 p-3 rounded-full mx-1"
                       onClick={() => {
                         setUndoStack((prev) => [
                           ...prev,

--- a/src/components/EditorSidePanel/TablesTab/TablesTab.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TablesTab.jsx
@@ -46,10 +46,17 @@ export default function TablesTab() {
           {tables.map((t) => (
             <div id={`scroll_table_${t.id}`} key={t.id}>
               <Collapse.Panel
+                className="relative"
                 header={
-                  <div className="overflow-hidden text-ellipsis whitespace-nowrap">
-                    {t.name}
-                  </div>
+                  <>
+                    <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+                      {t.name}
+                    </div>
+                    <div
+                      className="w-1 h-full absolute top-0 left-0 bottom-0"
+                      style={{ backgroundColor: t.color }}
+                    />
+                  </>
                 }
                 itemKey={`${t.id}`}
               >


### PR DESCRIPTION
- Add color to table to make it easier to find
<img width="1680" alt="image" src="https://github.com/drawdb-io/drawdb/assets/67461134/70ddb98c-cc2e-4557-830b-72cfd82ef79f">

- Adjust width, height in note's theme selection