### PR TITLE
fix: update remaining vercel urls to drawdb.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">Free, simple, and intuitive database design tool and SQL generator.</h3>
 
 <p align="center">
-    <a href="https://drawdb.vercel.app/">drawDB</a>
+    <a href="https://drawdb.app/">drawDB</a>
     ·  
     <a href="https://discord.gg/BrjZgNrmR6">Discord</a>
     ·  

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta name="robots" content="index,follow,max-image-preview:large" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://drawdb.vercel.app/" />
+    <meta property="og:url" content="https://drawdb.app/" />
     <meta
       property="og:title"
       content="drawDB | Online database diagram editor and SQL generator"
@@ -23,15 +23,15 @@
       property="og:description"
       content="Online database entity-realtionship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
     />
-    <meta property="og:image" content="https://drawdb.vercel.app/hero_ss.png" />
+    <meta property="og:image" content="https://drawdb.app/hero_ss.png" />
 
     <meta
       name="twitter:image:src"
-      content="https://drawdb.vercel.app/hero_ss.png"
+      content="https://drawdb.app/hero_ss.png"
     />
     <meta
       name="twitter:tile:image"
-      content="https://drawdb.vercel.app/hero_ss.png"
+      content="https://drawdb.app/hero_ss.png"
     />
     <meta name="twitter:card" content="summary_large_image" />
 


### PR DESCRIPTION
@1ilit started making similar changes in 4cc0811.

This commit performs a full search and replace for `drawdb.vercel.app` to `drawdb.app`, fixing remaining "bad" urls.