### PR TITLE
feat: support horizontal scrolling

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -468,7 +468,7 @@ export default function Canvas() {
         setTransform((prev) => ({
           ...prev,
           pan: {
-            ...prev.pan,
+            x: prev.pan.x + e.deltaX / prev.zoom,
             y: prev.pan.y + e.deltaY / prev.zoom,
           },
         }));


### PR DESCRIPTION
Ran across this as I was starting work on a diagram from my laptop. Simple fix.

Certain input devices, such as laptop touchpads, support horizontal scrolling. This commit adds support for such horizontal scroll inputs.