### PR TITLE
Fix: Add dash between words in autoincrement label

### DIFF
--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -113,7 +113,7 @@ const en = {
     not_null: "Not null",
     primary: "Primary",
     unique: "Unique",
-    autoincrement: "Autoincrement",
+    autoincrement: "Auto-increment",
     default_value: "Default",
     check: "Check expression",
     this_will_appear_as_is: "*This will appear in the generated script as is.",


### PR DESCRIPTION
### Description
- Added a dash in the english "autoincrement" label

### Motivation
It kind of bothered me that it was one word haha