### PR TITLE
Fix typos in the English (en.js) translation

### DIFF
--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -183,7 +183,7 @@ const en = {
     no_primary_key: "Table '{{tableName}}' has no primary key",
     type_with_no_name: "Declared a type with no name",
     duplicate_types: "Duplicate types by the name '{{typeName}}'",
-    type_w_no_fields: "Declared an empty type '{{typeName}}'with no fields",
+    type_w_no_fields: "Declared an empty type '{{typeName}}' with no fields",
     empty_type_field_name: "Empty field `name` in type '{{typeName}}'",
     empty_type_field_type: "Empty field `type` in type '{{typeName}}'",
     no_values_for_type_field:
@@ -191,7 +191,7 @@ const en = {
     duplicate_type_fields:
       "Duplicate type fields by name '{{fieldName}}' in type '{{typeName}}'",
     duplicate_reference: "Duplicate reference by the name '{{refName}}'",
-    circular_dependency: "Circular dependency involvind table '{{refName}}'",
+    circular_dependency: "Circular dependency involving table '{{refName}}'",
     timeline: "Timeline",
     priority: "Priority",
     none: "None",


### PR DESCRIPTION
### Changes
- Fixed two small typos in en.js