### PR TITLE
Fix multi line field comments in SQL export.

### DIFF
--- a/src/utils/exportSQL/mariadb.js
+++ b/src/utils/exportSQL/mariadb.js
@@ -1,5 +1,6 @@
+import { exportFieldComment, parseDefault } from "./shared";
+
 import { dbToTypes } from "../../data/datatypes";
-import { parseDefault } from "./shared";
 
 export function toMariaDB(diagram) {
   return `${diagram.tables
@@ -10,7 +11,7 @@ export function toMariaDB(diagram) {
         }CREATE OR REPLACE TABLE \`${table.name}\` (\n${table.fields
           .map(
             (field) =>
-              `${field.comment === "" ? "" : `\t-- ${field.comment}\n`}\t\`${
+              `${exportFieldComment(field.comment)}\t\`${
                 field.name
               }\` ${field.type}${field.notNull ? " NOT NULL" : ""}${
                 field.increment ? " AUTO_INCREMENT" : ""

--- a/src/utils/exportSQL/mssql.js
+++ b/src/utils/exportSQL/mssql.js
@@ -1,5 +1,6 @@
+import { exportFieldComment, parseDefault } from "./shared";
+
 import { dbToTypes } from "../../data/datatypes";
-import { parseDefault } from "./shared";
 
 export function toMSSQL(diagram) {
   return `${diagram.tables
@@ -10,7 +11,7 @@ export function toMSSQL(diagram) {
         }CREATE TABLE [${table.name}] (\n${table.fields
           .map(
             (field) =>
-              `${field.comment === "" ? "" : `\t-- ${field.comment}\n`}\t[${
+              `${exportFieldComment(field.comment)}\t[${
                 field.name
               }] ${field.type}${
                 field.notNull ? " NOT NULL" : ""

--- a/src/utils/exportSQL/mysql.js
+++ b/src/utils/exportSQL/mysql.js
@@ -1,5 +1,6 @@
+import { exportFieldComment, parseDefault } from "./shared";
+
 import { dbToTypes } from "../../data/datatypes";
-import { parseDefault } from "./shared";
 
 export function toMySQL(diagram) {
   return `${diagram.tables
@@ -10,9 +11,9 @@ export function toMySQL(diagram) {
         }CREATE TABLE \`${table.name}\` (\n${table.fields
           .map(
             (field) =>
-              `${field.comment === "" ? "" : `\t-- ${field.comment}\n`}\t\`${
+              `${exportFieldComment(field.comment)}\t\`${
                 field.name
-              }\` ${field.type}${(field.size !== undefined && field.size !== "")? "(" + field.size + ")" : ""}${
+              }\` ${field.type}${field.size !== undefined && field.size !== "" ? "(" + field.size + ")" : ""}${
                 field.notNull ? " NOT NULL" : ""
               }${
                 field.increment ? " AUTO_INCREMENT" : ""

--- a/src/utils/exportSQL/postgres.js
+++ b/src/utils/exportSQL/postgres.js
@@ -1,5 +1,6 @@
+import { exportFieldComment, parseDefault } from "./shared";
+
 import { dbToTypes } from "../../data/datatypes";
-import { parseDefault } from "./shared";
 
 export function toPostgres(diagram) {
   const enumStatements = diagram.enums
@@ -28,7 +29,7 @@ export function toPostgres(diagram) {
         `CREATE TABLE "${table.name}" (\n${table.fields
           .map(
             (field) =>
-              `${field.comment === "" ? "" : `\t-- ${field.comment}\n`}\t"${
+              `${exportFieldComment(field.comment)}\t"${
                 field.name
               }" ${field.type}${field.isArray ? " ARRAY" : ""}${field.notNull ? " NOT NULL" : ""}${field.unique ? " UNIQUE" : ""}${
                 field.default.trim() !== ""

--- a/src/utils/exportSQL/shared.js
+++ b/src/utils/exportSQL/shared.js
@@ -1,6 +1,7 @@
+import { isFunction, isKeyword, strHasQuotes } from "../utils";
+
 import { DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { isFunction, isKeyword, strHasQuotes } from "../utils";
 
 export function parseDefault(field, database = DB.GENERIC) {
   if (
@@ -13,4 +14,15 @@ export function parseDefault(field, database = DB.GENERIC) {
   }
 
   return `'${field.default}'`;
+}
+
+export function exportFieldComment(comment) {
+  if (comment === "") {
+    return "";
+  }
+
+  return comment
+    .split("\n")
+    .map((commentLine) => `\t-- ${commentLine}\n`)
+    .join("");
 }

--- a/src/utils/exportSQL/sqlite.js
+++ b/src/utils/exportSQL/sqlite.js
@@ -1,5 +1,6 @@
+import { exportFieldComment, parseDefault } from "./shared";
+
 import { dbToTypes } from "../../data/datatypes";
-import { parseDefault } from "./shared";
 
 export function toSqlite(diagram) {
   return diagram.tables
@@ -10,7 +11,7 @@ export function toSqlite(diagram) {
       }CREATE TABLE IF NOT EXISTS "${table.name}" (\n${table.fields
         .map(
           (field) =>
-            `${field.comment === "" ? "" : `\t-- ${field.comment}\n`}\t"${
+            `${exportFieldComment(field.comment)}\t"${
               field.name
             }" ${field.type}${field.notNull ? " NOT NULL" : ""}${
               field.unique ? " UNIQUE" : ""


### PR DESCRIPTION
Currently field comments with multiple lines are exported like this:
```
CREATE TABLE "User" (
	"id" INTEGER NOT NULL UNIQUE,
	-- line1
line2
line3
	"name" VARCHAR,
	PRIMARY KEY("id")
);
```

This PR fixes it so that multiple-line comments export correctly:
```
CREATE TABLE "User" (
	"id" INTEGER NOT NULL UNIQUE,
	-- line1
	-- line2
	-- line3
	"name" VARCHAR,
	PRIMARY KEY("id")
);
```
