### PR TITLE
[Feature] Add Documentation Menu with Markdown Export for Database Documentation

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1062,29 +1062,24 @@ export default function ControlPanel({
               }));
             },
           },
-        ],
-        function: () => {},
-      },
-      documentation: {
-        children: [
-            {
-              Markdown: () => {
-                setModal(MODAL.CODE);
-                const result = jsonToDocumentation({
-                  tables: tables,
-                  relationships: relationships,
-                  notes: notes,
-                  subjectAreas: areas,
-                  database: database,
-                  title: title,
-                });
-                setExportData((prev) => ({
-                  ...prev,
-                  data: result,
-                  extension: "md",
-                }));
-              }
+          {
+            Readme: () => {
+              setModal(MODAL.CODE);
+              const result = jsonToDocumentation({
+                tables: tables,
+                relationships: relationships,
+                notes: notes,
+                subjectAreas: areas,
+                database: database,
+                title: title,
+              });
+              setExportData((prev) => ({
+                ...prev,
+                data: result,
+                extension: "md",
+              }));
             }
+          },
         ],
         function: () => {},
       },

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -70,6 +70,7 @@ import { exportSQL } from "../../utils/exportSQL";
 import { databases } from "../../data/databases";
 import { jsonToMermaid } from "../../utils/exportAs/mermaid";
 import { isRtl } from "../../i18n/utils/rtl";
+import { jsonToDocumentation } from "../../utils/exportAs/documentation";
 
 export default function ControlPanel({
   diagramId,
@@ -1061,6 +1062,29 @@ export default function ControlPanel({
               }));
             },
           },
+        ],
+        function: () => {},
+      },
+      Documentation: {
+        children: [
+            {
+              Markdown: () => {
+                setModal(MODAL.CODE);
+                const result = jsonToDocumentation({
+                  tables: tables,
+                  relationships: relationships,
+                  notes: notes,
+                  subjectAreas: areas,
+                  database: database,
+                  title: title,
+                });
+                setExportData((prev) => ({
+                  ...prev,
+                  data: result,
+                  extension: "md",
+                }));
+              }
+            }
         ],
         function: () => {},
       },

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1065,7 +1065,7 @@ export default function ControlPanel({
         ],
         function: () => {},
       },
-      Documentation: {
+      documentation: {
         children: [
             {
               Markdown: () => {

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1072,6 +1072,8 @@ export default function ControlPanel({
                 subjectAreas: areas,
                 database: database,
                 title: title,
+                ...(databases[database].hasTypes && { types: types }),
+                ...(databases[database].hasEnums && { enums: enums }),
               });
               setExportData((prev) => ({
                 ...prev,

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1063,7 +1063,7 @@ export default function ControlPanel({
             },
           },
           {
-            Readme: () => {
+            readme: () => {
               setModal(MODAL.CODE);
               const result = jsonToDocumentation({
                 tables: tables,

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -236,7 +236,6 @@ const en = {
     empty_index_name: "Declared an index with no name in table '{{tableName}}'",
     didnt_find_diagram: "Oops! Didn't find the diagram.",
     unsigned: "Unsigned",
-    documentation: "Documentation",
   },
 };
 

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -236,6 +236,7 @@ const en = {
     empty_index_name: "Declared an index with no name in table '{{tableName}}'",
     didnt_find_diagram: "Oops! Didn't find the diagram.",
     unsigned: "Unsigned",
+    readme: "README",
   },
 };
 

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -236,6 +236,7 @@ const en = {
     empty_index_name: "Declared an index with no name in table '{{tableName}}'",
     didnt_find_diagram: "Oops! Didn't find the diagram.",
     unsigned: "Unsigned",
+    documentation: "Documentation",
   },
 };
 

--- a/src/i18n/locales/es.js
+++ b/src/i18n/locales/es.js
@@ -212,6 +212,7 @@ const es = {
     edit_relationship: "{{extra}} Editar relación {{refName}}",
     delete_relationship: "Eliminar relación {{refName}}",
     not_found: "No encontrado",
+    readme: "README",
   },
 };
 

--- a/src/i18n/locales/es.js
+++ b/src/i18n/locales/es.js
@@ -212,7 +212,6 @@ const es = {
     edit_relationship: "{{extra}} Editar relación {{refName}}",
     delete_relationship: "Eliminar relación {{refName}}",
     not_found: "No encontrado",
-    documentation: "Documentación",
   },
 };
 

--- a/src/i18n/locales/es.js
+++ b/src/i18n/locales/es.js
@@ -212,6 +212,7 @@ const es = {
     edit_relationship: "{{extra}} Editar relación {{refName}}",
     delete_relationship: "Eliminar relación {{refName}}",
     not_found: "No encontrado",
+    documentation: "Documentación",
   },
 };
 

--- a/src/i18n/locales/fr.js
+++ b/src/i18n/locales/fr.js
@@ -217,6 +217,7 @@ const fr = {
     edit_relationship: "{{extra}} Modifier la relation {{refName}}",
     delete_relationship: "Supprimer la relation {{refName}}",
     not_found: "Non trouvé",
+    readme: "README",
   },
 };
 

--- a/src/i18n/locales/fr.js
+++ b/src/i18n/locales/fr.js
@@ -217,6 +217,7 @@ const fr = {
     edit_relationship: "{{extra}} Modifier la relation {{refName}}",
     delete_relationship: "Supprimer la relation {{refName}}",
     not_found: "Non trouvé",
+    documentation: "Documentation",
   },
 };
 

--- a/src/i18n/locales/fr.js
+++ b/src/i18n/locales/fr.js
@@ -217,7 +217,6 @@ const fr = {
     edit_relationship: "{{extra}} Modifier la relation {{refName}}",
     delete_relationship: "Supprimer la relation {{refName}}",
     not_found: "Non trouvé",
-    documentation: "Documentation",
   },
 };
 

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -1,5 +1,6 @@
 import { dbToTypes } from "../../data/datatypes";
 import { jsonToMermaid } from "./mermaid";
+import { databases } from "../../data/databases";
 
 export function jsonToDocumentation(obj) {
 
@@ -44,16 +45,13 @@ export function jsonToDocumentation(obj) {
       .map((r) => {
         const startTable = obj.tables[r.startTableId].name;
         const endTable = obj.tables[r.endTableId].name;
-        return `- **${startTable} to ${endTable}**: ${r.cardinality} ${r.comment ? "(" + r.comment + ")" : ""}\n`;
+        return `- **${startTable} to ${endTable}**: ${r.cardinality}\n`;
       }).join("") : "";
-  
-  console.log(obj.tables);
-  console.log(obj.relationships);
   
   return `# ${obj.title} documentation\n## Summary\n\n- [Introduction](#introduction)\n- [Database Type](#database-type)\n`+
           `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n\n`+
           `## Introduction\n\n## Database type\n\n- **Database system:** `+
-          `${obj.database.type}\n## Table structure\n\n${documentationEntities}`+
+    `${databases[obj.database].name}\n## Table structure\n\n${documentationEntities}`+
           `\n\n## Relationships\n\n${documentationRelationships}\n\n`+
           `## Database Diagram\n\n\`\`\`${jsonToMermaid(obj)}\`\`\``;
 }

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -65,6 +65,6 @@ export function jsonToDocumentation(obj) {
           `## Introduction\n\n## Database type\n\n- **Database system:** `+
           `${databases[obj.database].name}\n## Table structure\n\n${documentationEntities}`+
           `\n## Relationships\n\n${documentationRelationships}\n` +
-          `${databases[obj.database].hasTypes && obj.types.length > 0 ? `## Types\n\n` + documentationTypes`\n\n` : "" }` +
+          `${databases[obj.database].hasTypes && obj.types.length > 0 ? `## Types\n\n` + documentationTypes + `\n\n` : "" }` +
           `## Database Diagram\n\n\`\`\`mermaid\n${jsonToMermaid(obj)}\n\`\`\``;
 }

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -5,8 +5,8 @@ export function jsonToDocumentation(obj) {
 
   const documentationSummary = obj.tables
     .map((table) => {
-      return `\t- [${table.name}](#${table.name})\n`;
-    }).join("");
+      return `\t- [${table.name}](#${table.name})`;
+    }).join("\n");
 
   const documentationEntities = obj.tables
     .map((table) => {
@@ -22,7 +22,9 @@ export function jsonToDocumentation(obj) {
               : "");
           return `| **${field.name}** | ${fieldType} | ${field.primary ? "🔑 PK, " : ""}` +
             `${field.nullable ? "null " : "not null "}${field.unique ? ", unique" : ""}${field.increment?", autoincrement":""}` +
-            `${field.default ? `, default: ${field.default}` : ""} | |${field.comment ? field.comment : ""} |`;
+            `${field.default ? `, default: ${field.default}` : ""} | ` +
+            `${relationshipByField(table.id, obj.relationships, field.id)}` +
+            ` |${field.comment ? field.comment : ""} |`;
 
         }).join("\n");
       return `### ${table.name}\n${table.comment ? table.comment : ""}\n` +
@@ -31,17 +33,25 @@ export function jsonToDocumentation(obj) {
         `${fields}\n\n`;
     }).join("");
   
+  function relationshipByField(table, relationships, fieldId) {
+    return relationships.filter(r => r.startTableId === table && r.startFieldId === fieldId)
+              .map((rel) => rel.name);
+
+  }
+  
   const documentationRelationships = obj.relationships?.length
     ? obj.relationships
       .map((r) => {
-        console.log(r);
         const startTable = obj.tables[r.startTableId].name;
         const endTable = obj.tables[r.endTableId].name;
         return `- **${startTable} to ${endTable}**: ${r.cardinality} (${r.comment ? r.comment : ""})\n`;
       }).join("") : "";
   
+  console.log(obj.tables);
+  console.log(obj.relationships);
+  
   return `# ${obj.title} Database Documentation\n## Summary\n- [Introduction](#introduction)\n- [Database Type](#database-type)\n`+
-          `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n`+
+          `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n\n`+
           `## Introduction\n${obj.notes}\n## Database type\n- **Database system:** `+
           `${obj.database.type}\n## Table structure\n\n${documentationEntities}`+
           `\n\n## Relationships\n${documentationRelationships}\n\n`+

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -38,7 +38,7 @@ export function jsonToDocumentation(obj) {
         `|-------------|---------------|-------------------------------|-------------------------------|--------------------------------|\n` +
         `${fields} \n${enums.length > 0 ? "\n#### Enums\n" + enums : ""}\n` +
         `${indexes.length > 0 ? "\n#### Indexes\n| Name | Unique | Fields |\n|------|--------|--------|\n" + indexes : ""}`;
-    }).join("\n\n");
+    }).join("\n");
   
   function relationshipByField(table, relationships, fieldId) {
     return relationships.filter(r => r.startTableId === table && r.startFieldId === fieldId)
@@ -64,7 +64,7 @@ export function jsonToDocumentation(obj) {
           `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n\n`+
           `## Introduction\n\n## Database type\n\n- **Database system:** `+
           `${databases[obj.database].name}\n## Table structure\n\n${documentationEntities}`+
-          `\n\n## Relationships\n\n${documentationRelationships}\n\n` +
-          `## Types\n\n${documentationTypes}\n\n` +
+          `\n## Relationships\n\n${documentationRelationships}\n` +
+          `${databases[obj.database].hasTypes && obj.types.length > 0 ? `## Types\n\n` + documentationTypes`\n\n` : "" }` +
           `## Database Diagram\n\n\`\`\`mermaid\n${jsonToMermaid(obj)}\n\`\`\``;
 }

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -27,7 +27,7 @@ export function jsonToDocumentation(obj) {
             ` |${field.comment ? field.comment : ""} |`;
 
         }).join("\n");
-      return `### ${table.name}\n${table.comment ? table.comment : ""}\n` +
+      return `### ${table.name}\n${table.comment ? table.comment : ""}\n\n` +
         `| Name        | Type          | Settings                      | References                    | Note                           |\n` +
         `|-------------|---------------|-------------------------------|-------------------------------|--------------------------------|\n` +
         `${fields}\n\n`;
@@ -44,16 +44,16 @@ export function jsonToDocumentation(obj) {
       .map((r) => {
         const startTable = obj.tables[r.startTableId].name;
         const endTable = obj.tables[r.endTableId].name;
-        return `- **${startTable} to ${endTable}**: ${r.cardinality} (${r.comment ? r.comment : ""})\n`;
+        return `- **${startTable} to ${endTable}**: ${r.cardinality} ${r.comment ? "(" + r.comment + ")" : ""}\n`;
       }).join("") : "";
   
   console.log(obj.tables);
   console.log(obj.relationships);
   
-  return `# ${obj.title} Database Documentation\n## Summary\n- [Introduction](#introduction)\n- [Database Type](#database-type)\n`+
+  return `# ${obj.title} documentation\n## Summary\n\n- [Introduction](#introduction)\n- [Database Type](#database-type)\n`+
           `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n\n`+
-          `## Introduction\n${obj.notes}\n## Database type\n- **Database system:** `+
+          `## Introduction\n\n## Database type\n\n- **Database system:** `+
           `${obj.database.type}\n## Table structure\n\n${documentationEntities}`+
-          `\n\n## Relationships\n${documentationRelationships}\n\n`+
-          `## Database Diagram\n\`\`\`${jsonToMermaid(obj)}\`\`\``;
+          `\n\n## Relationships\n\n${documentationRelationships}\n\n`+
+          `## Database Diagram\n\n\`\`\`${jsonToMermaid(obj)}\`\`\``;
 }

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -54,11 +54,11 @@ export function jsonToDocumentation(obj) {
         return `- **${startTable} to ${endTable}**: ${r.cardinality}\n`;
       }).join("") : "";
   
-  const documentationTypes = obj.types.map((type) => {
+  const documentationTypes = databases[obj.database].hasTypes && obj.types.length > 0 ? obj.types.map((type) => {
     return `| Name        | fields        | Note                           |\n` +
            `|-------------|---------------|--------------------------------|\n` +
            `| ${type.name} | ${type.fields.map((field) => field.name).join(", ")} | ${type.comment ? type.comment : ""} |`;
-  }).join("\n");
+  }).join("\n") : "";
   
   return `# ${obj.title} documentation\n## Summary\n\n- [Introduction](#introduction)\n- [Database Type](#database-type)\n`+
           `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n\n`+

--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -1,0 +1,49 @@
+import { dbToTypes } from "../../data/datatypes";
+import { jsonToMermaid } from "./mermaid";
+
+export function jsonToDocumentation(obj) {
+
+  const documentationSummary = obj.tables
+    .map((table) => {
+      return `\t- [${table.name}](#${table.name})\n`;
+    }).join("");
+
+  const documentationEntities = obj.tables
+    .map((table) => {
+      const fields = table.fields
+        .map((field) => {
+          const fieldType =
+            field.type +
+            ((dbToTypes[obj.database][field.type].isSized ||
+              dbToTypes[obj.database][field.type].hasPrecision) &&
+            field.size &&
+            field.size !== ""
+              ? "(" + field.size + ")"
+              : "");
+          return `| **${field.name}** | ${fieldType} | ${field.primary ? "🔑 PK, " : ""}` +
+            `${field.nullable ? "null " : "not null "}${field.unique ? ", unique" : ""}${field.increment?", autoincrement":""}` +
+            `${field.default ? `, default: ${field.default}` : ""} | |${field.comment ? field.comment : ""} |`;
+
+        }).join("\n");
+      return `### ${table.name}\n${table.comment ? table.comment : ""}\n` +
+        `| Name        | Type          | Settings                      | References                    | Note                           |\n` +
+        `|-------------|---------------|-------------------------------|-------------------------------|--------------------------------|\n` +
+        `${fields}\n\n`;
+    }).join("");
+  
+  const documentationRelationships = obj.relationships?.length
+    ? obj.relationships
+      .map((r) => {
+        console.log(r);
+        const startTable = obj.tables[r.startTableId].name;
+        const endTable = obj.tables[r.endTableId].name;
+        return `- **${startTable} to ${endTable}**: ${r.cardinality} (${r.comment ? r.comment : ""})\n`;
+      }).join("") : "";
+  
+  return `# ${obj.title} Database Documentation\n## Summary\n- [Introduction](#introduction)\n- [Database Type](#database-type)\n`+
+          `- [Table Structure](#table-structure)\n${documentationSummary}\n- [Relationships](#relationships)\n- [Database Diagram](#database-Diagram)\n`+
+          `## Introduction\n${obj.notes}\n## Database type\n- **Database system:** `+
+          `${obj.database.type}\n## Table structure\n\n${documentationEntities}`+
+          `\n\n## Relationships\n${documentationRelationships}\n\n`+
+          `## Database Diagram\n\`\`\`${jsonToMermaid(obj)}\`\`\``;
+}


### PR DESCRIPTION
#### What
This pull request introduces a new "Documentation" menu item to the application, allowing users to export database documentation in Markdown format. The documentation is structured in a data dictionary format, including details such as table names, columns, constraints, indexes, and relationships.

#### Why
The purpose of this feature is to enhance the user experience by providing a streamlined way to generate and export database documentation in Markdown format. This allows users to easily share, review, and manage the database schema in a widely accepted and readable format.

#### How
- **Add Documentation Menu:**
  - A new menu item labeled "Documentation" has been added to the application's main menu.
  - Under the "Documentation" menu, an option labeled "Export as Markdown" has been included.

- **Generate Markdown Documentation:**
  - On selecting "Export as Markdown," a new window opens, displaying a preview of the database documentation in Markdown format.
  - The Markdown documentation is organized as follows:
    - **Table Names**: Each table in the database is clearly labeled.
    - **Columns**: For each table, the following details are listed:
      - Column Name
      - Data Type
      - Constraints (Primary Key, Foreign Key, Unique)
      - Default Values (if any)
      - Nullable (yes/no)
    - **Relationships**: Foreign key references and other relationships between tables are described.

- **Export Functionality:**
  - An "Export" button is provided in the Markdown preview window.
  - Upon clicking "Export," the Markdown file is downloaded to the user's machine.

close  #228 