### PR TITLE
fix casing do not match warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the app
-FROM node:20-alpine as build
+FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Setup the Nginx Server to serve the app
-FROM nginx:stable-alpine3.17 as production
+FROM nginx:stable-alpine3.17 AS production
 COPY --from=build /app/dist /usr/share/nginx/html
 RUN echo 'server { listen 80; server_name _; root /usr/share/nginx/html;  location / { try_files $uri /index.html; } }' > /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
Remove 

```
2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 10)
```

Following the recommendations [https://docs.docker.com/reference/build-checks/from-as-casing/](https://docs.docker.com/reference/build-checks/from-as-casing/)