### PR TITLE
[FIX #259] use custom types when importing from postgresql

### DIFF
--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -38,8 +38,16 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
           if (d.resource === "column") {
             field.name = d.column.column.expr.value;
 
-            let type = types.find((t) => t.name === d.definition.dataType)?.name
-            type ??= enums.find((t) => t.name === d.definition.dataType)?.name
+            let type = types.find((t) =>
+              new RegExp(`^(${t.name}|"${t.name}")$`).test(
+                d.definition.dataType,
+              ),
+            )?.name;
+            type ??= enums.find((t) =>
+              new RegExp(`^(${t.name}|"${t.name}")$`).test(
+                d.definition.dataType,
+              ),
+            )?.name;
             if (!type && !dbToTypes[diagramDb][type])
               type = affinity[diagramDb][type];
             field.type = type || d.definition.dataType;

--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -38,11 +38,11 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
           if (d.resource === "column") {
             field.name = d.column.column.expr.value;
 
-            let type = d.definition.dataType;
-            if (!dbToTypes[diagramDb][type]) {
+            let type = types.find((t) => t.name === d.definition.dataType)?.name
+            type ??= enums.find((t) => t.name === d.definition.dataType)?.name
+            if (!type && !dbToTypes[diagramDb][type])
               type = affinity[diagramDb][type];
-            }
-            field.type = type;
+            field.type = type || d.definition.dataType;
 
             if (d.definition.expr && d.definition.expr.type === "expr_list") {
               field.values = d.definition.expr.value.map((v) => v.value);


### PR DESCRIPTION
fixes #259 and allows for composite types to be imported as well.

I tested this against #259 [SQL file](https://github.com/user-attachments/files/17343814/test.sql.txt) and [test.sql.txt](https://github.com/user-attachments/files/17348401/test.sql.txt)

again let me know if any changes need to be made there are any issues or test cases that should be considered :)

---
related issues I discovered
- [ ] proper export of composite types -- using "export SQL" (syntax errors -- missing commas between fields)
- [ ] imported types containing enums are not maintained (presumably for composite types too)

I'll look into fixing these in a separate pr, probably 