### PR TITLE
Make buttons more responsive

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -88,9 +88,9 @@ export default function LandingPage() {
                 </div>
               </div>
             </FadeIn>
-            <div className="flex items-start justify-start gap-4 mt-4 font-semibold md:mt-12">
+            <div className="mt-4 font-semibold md:mt-12">
               <button
-                className="py-3 transition-all duration-300 bg-white border rounded-full shadow-lg px-9 border-zinc-200 hover:bg-zinc-100"
+                className="py-3 mb-4 xl:mb-0 mr-4 transition-all duration-300 bg-white border rounded-full shadow-lg px-9 border-zinc-200 hover:bg-zinc-100"
                 onClick={() =>
                   document
                     .getElementById("learn-more")

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -88,9 +88,9 @@ export default function LandingPage() {
                 </div>
               </div>
             </FadeIn>
-            <div className="mt-4 flex gap-4 justify-start font-semibold md:block md:mt-12">
+            <div className="flex items-start justify-start gap-4 mt-4 font-semibold md:mt-12">
               <button
-                className="bg-white shadow-lg px-9 py-3 rounded-full border border-zinc-200 hover:bg-zinc-100 transition-all duration-300"
+                className="py-3 transition-all duration-300 bg-white border rounded-full shadow-lg px-9 border-zinc-200 hover:bg-zinc-100"
                 onClick={() =>
                   document
                     .getElementById("learn-more")
@@ -101,7 +101,7 @@ export default function LandingPage() {
               </button>
               <Link
                 to="/editor"
-                className="md:mt-2 inline-block bg-sky-900 text-white ps-7 pe-6 py-3 rounded-full shadow-lg hover:bg-sky-800 transition-all duration-300"
+                className="inline-block py-3 text-white transition-all duration-300 rounded-full shadow-lg bg-sky-900 ps-7 pe-6 hover:bg-sky-800"
               >
                 Try it for yourself <i className="bi bi-arrow-right ms-1"></i>
               </Link>


### PR DESCRIPTION
On tablets and larger phone screens, these two were lacking a margin setting (leading to a "squished" look). This commit resolves that.

**Before:**

<img width="450" alt="Screenshot 2024-10-14 at 18 09 48" src="https://github.com/user-attachments/assets/1164694a-8cf2-4cc0-b3ed-d9c607ccd63c">
<img width="455" alt="Screenshot 2024-10-14 at 18 10 14" src="https://github.com/user-attachments/assets/8ab151bb-c4e9-41bc-a4c6-344d10dfc917">

**After:**

<img width="456" alt="Screenshot 2024-10-14 at 18 12 59" src="https://github.com/user-attachments/assets/a3a7f509-7f9d-4532-8947-1139d104b42d">
<img width="456" alt="Screenshot 2024-10-14 at 18 13 58" src="https://github.com/user-attachments/assets/ac5bc151-f99a-4deb-9280-9ddb637581f1">
