### PR TITLE
Extended the NVARCHAR(MAX) for MSSQL

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -1616,6 +1616,15 @@ const mssqlTypesBase = {
     defaultSize: 255,
     hasQuotes: true,
   },
+  'NVARCHAR(MAX)': {
+    type: "NVARCHAR",
+    checkDefault: (field) => true,
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    defaultSize: 'MAX',
+    hasQuotes: true,
+  },
   TEXT: {
     type: "TEXT",
     checkDefault: (field) => true,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6c131f8-c717-45ac-9384-6cd0171a0ac4)
Checked by exporting whether the right query is generating or not. Also checked with mapping of two tables is getting done correctly or not when two fields with NVARCHAR(MAX) are tried to mapped. 
Results are as expected.