### PR TITLE
Allow setting default value on UUID columns

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -237,7 +237,7 @@ const defaultTypesBase = {
     isSized: false,
     hasCheck: false,
     hasPrecision: false,
-    noDefault: true,
+    noDefault: false,
   },
   ENUM: {
     type: "ENUM",
@@ -1208,7 +1208,7 @@ const postgresTypesBase = {
     isSized: false,
     hasPrecision: false,
     hasQuotes: true,
-    noDefault: true,
+    noDefault: false,
   },
   XML: {
     type: "XML",

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,11 @@
   color: inherit;
 }
 
+:disabled {
+  /* inherit Semi's cursor style for disabled elements */
+  cursor: inherit;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;


### PR DESCRIPTION
Closes #338.

This PR sets the `noDefault` property of UUID types (generic and Postgres) to `false` so that default values can be set on UUID columns:

![image](https://github.com/user-attachments/assets/41a7bf52-041c-474e-a739-8042735de1b8)

This PR also forces the cursor style of disabled elements to be inherited from SemiDesign's classes:

![image](https://github.com/user-attachments/assets/82857208-9599-4ec9-9066-01a03e83bd9a)

![image](https://github.com/user-attachments/assets/5595f1b4-3d4e-45cb-9cd7-3fda09e7aeb3)
([SemiDesign documentation page](https://semi.design/en-US/input/input#Disabled))


