### PR TITLE
Toggle datatypes for table directly from view dropdown

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -356,17 +356,21 @@ export default function Table(props) {
             />
           ) : (
             <div className="flex gap-1 items-center">
-              {fieldData.primary && <IconKeyStroked />}
-              {!fieldData.notNull && <span>?</span>}
-              <span>
-                {fieldData.type +
-                  ((dbToTypes[database][fieldData.type].isSized ||
-                    dbToTypes[database][fieldData.type].hasPrecision) &&
-                  fieldData.size &&
-                  fieldData.size !== ""
-                    ? "(" + fieldData.size + ")"
-                    : "")}
-              </span>
+              {settings.showDataTypes && (
+                <>
+                  {fieldData.primary && <IconKeyStroked />}
+                  {!fieldData.notNull && <span>?</span>}
+                  <span>
+                    {fieldData.type +
+                      ((dbToTypes[database][fieldData.type].isSized ||
+                        dbToTypes[database][fieldData.type].hasPrecision) &&
+                        fieldData.size &&
+                        fieldData.size !== ""
+                        ? "(" + fieldData.size + ")"
+                        : "")}
+                  </span>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -354,25 +354,22 @@ export default function Table(props) {
               icon={<IconMinus />}
               onClick={() => deleteField(fieldData, tableData.id)}
             />
-          ) : (
+          ) : settings.showDataTypes ? (
             <div className="flex gap-1 items-center">
-              {settings.showDataTypes && (
-                <>
-                  {fieldData.primary && <IconKeyStroked />}
-                  {!fieldData.notNull && <span>?</span>}
-                  <span>
-                    {fieldData.type +
-                      ((dbToTypes[database][fieldData.type].isSized ||
-                        dbToTypes[database][fieldData.type].hasPrecision) &&
-                        fieldData.size &&
-                        fieldData.size !== ""
-                        ? "(" + fieldData.size + ")"
-                        : "")}
-                  </span>
-                </>
-              )}
+              {fieldData.primary && <IconKeyStroked />}
+              {!fieldData.notNull && <span>?</span>}
+              <span>
+                {fieldData.type +
+                  ((dbToTypes[database][fieldData.type].isSized ||
+                    dbToTypes[database][fieldData.type].hasPrecision) &&
+                    fieldData.size &&
+                    fieldData.size !== ""
+                    ? `(${fieldData.size})`
+                    : "")}
+              </span>
             </div>
-          )}
+          ) : null
+          }
         </div>
       </div>
     );

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1217,10 +1217,8 @@ export default function ControlPanel({
         ) : (
           <i className="bi bi-toggle-off" />
         ),
-        function: () => {
-            showDataTypes: !prevSettings.showDataTypes
-          }));
-        },
+        function: () =>
+          setSettings((prev) => ({ ...prev, showDataTypes: !prev.showDataTypes })),
       },
       show_grid: {
         state: settings.showGrid ? (

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1211,6 +1211,18 @@ export default function ControlPanel({
         function: resetView,
         shortcut: "Ctrl+R",
       },
+      show_datatype: {
+        state: settings.showDataTypes ? (
+          <i className="bi bi-toggle-on" />
+        ) : (
+          <i className="bi bi-toggle-off" />
+        ),
+        function: () => {
+            showDataTypes: !prevSettings.showDataTypes
+          }));
+        },
+        shortcut: "Ctrl+Shift+D",
+      },
       show_grid: {
         state: settings.showGrid ? (
           <i className="bi bi-toggle-on" />

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1221,7 +1221,6 @@ export default function ControlPanel({
             showDataTypes: !prevSettings.showDataTypes
           }));
         },
-        shortcut: "Ctrl+Shift+D",
       },
       show_grid: {
         state: settings.showGrid ? (

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -5,6 +5,7 @@ const defaultSettings = {
   strictMode: false,
   showFieldSummary: true,
   showGrid: true,
+  showDataTypes: true,
   mode: "light",
   autosave: true,
   panning: true,

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -49,6 +49,7 @@ const en = {
     field_details: "Field details",
     reset_view: "Reset view",
     show_grid: "Show grid",
+    show_datatype: "Show datatype",
     show_cardinality: "Show cardinality",
     theme: "Theme",
     light: "Light",


### PR DESCRIPTION
proposed implementation

1- initially thought of creating a separate context and hook but the settings context did the provide a good base 
2- added an attribute(showDataTypes)  in settings context  
![image](https://github.com/user-attachments/assets/18a5d294-1d11-4ffa-b5be-e2a4cb727752)
3- in the en.js file created a reference 
![image](https://github.com/user-attachments/assets/cbb1067e-183a-4e84-8d04-fdb23f44aa7a)

4- In the ControlPanel.jsx file under view dropdown created the option show Datatype
![image](https://github.com/user-attachments/assets/155a0677-2c1c-4ecf-8960-0e4dd2512500)
5- finally in the table.jsx added condition to check settings.showDatatypes and return the element as per  condition
![image](https://github.com/user-attachments/assets/b28c49f9-f19d-490f-8137-4b3f5c268a3e)


**working** 
datatype -> onshow
![image](https://github.com/user-attachments/assets/f959127b-ca68-4927-bbc0-17921f45e0b1)

datatype-> off
![image](https://github.com/user-attachments/assets/cfb7c94a-9438-41ce-bd95-feb28d87ccb1)


Reference issue and pr  #346 
