### PR TITLE
Upgrade cross-spawn from 7.0.3 to 7.0.6 to mitigate CVE-2024-21538

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2805,10 +2805,11 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
Upgrade cross-spawn from 7.0.3 to 7.0.6 to mitigate CVE-2024-21538

https://security.snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230

Likely not urgent, but easy fix.