### PR TITLE
Add colors to data types in Popover (details of column)

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -210,7 +210,11 @@ export default function Table(props) {
                       style={{ direction: "ltr" }}
                     >
                       <p className="me-4 font-bold">{e.name}</p>
-                      <p className="ms-4">
+                      <p
+                        className={
+                          "ms-4 font-mono " + dbToTypes[database][e.type].color
+                        }
+                      >
                         {e.type +
                           ((dbToTypes[database][e.type].isSized ||
                             dbToTypes[database][e.type].hasPrecision) &&


### PR DESCRIPTION
I've added data type colors to the column detail Popover

From this

![image](https://github.com/user-attachments/assets/03c4d654-2ca4-4cd1-9779-85d0c582045b)

To this

![image](https://github.com/user-attachments/assets/5d3ceb1f-0341-4232-906a-fe8edd638383)

