### PR TITLE
Update table schema

### DIFF
--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -47,7 +47,12 @@ export const tableSchema = {
           unique: { type: "boolean" },
           fields: {
             type: "array",
-            items: { type: "string" },
+            items: { 
+                type: "object", properties: {
+                  type: { type: "string" },
+                  value: { type: "string" }
+                }
+            },
           },
         },
         required: ["name", "unique", "fields"],


### PR DESCRIPTION
When exporting a diagram that contains a table with indices to JSON then importing it, an validation error occurs because the schema for the index on the table was not correctly setup leading to the file being considered an invalid json.
<img width="608" alt="image" src="https://github.com/user-attachments/assets/1273c5bc-c592-41c1-9aa8-47f88222ec54" />

These are the errors thrown by an online validator using the old schema for reference
<img width="802" alt="image" src="https://github.com/user-attachments/assets/cf7c7564-0250-4ba7-88c5-f287f3dacdc9" />
