### PR TITLE
chore: upgrade node-sql-parser to v5.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "jszip": "^3.10.1",
         "lexical": "^0.12.5",
         "nanoid": "^5.1.5",
-        "node-sql-parser": "^5.3.9",
+        "node-sql-parser": "^5.3.10",
         "oracle-sql-parser": "^0.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -6267,9 +6267,9 @@
       "license": "MIT"
     },
     "node_modules/node-sql-parser": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.3.9.tgz",
-      "integrity": "sha512-yJuCNCUWqS296krMKooLIJcZy+Q0OL6ZsNDxrwqj+HdGMHVT0ChPIFF1vqCexDe51VWKEwhU65OgvKyiyRcQLg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.3.10.tgz",
+      "integrity": "sha512-cf+iXXJ9Foz4hBIu+eNNeg207ac6XruA9I9DXEs+jCxeS9t/k9T0GZK8NZngPwkv+P26i3zNFj9jxJU2v3pJnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/pegjs": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jszip": "^3.10.1",
     "lexical": "^0.12.5",
     "nanoid": "^5.1.5",
-    "node-sql-parser": "^5.3.9",
+    "node-sql-parser": "^5.3.10",
     "oracle-sql-parser": "^0.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
**Upgrade**  **node-sql-parser to v5.3.10**
This pull request updates the node-sql-parser dependency to version 5.3.10, addressing  #487 

Summary of Changes
Updated package.json and lockfile (package-lock.json or yarn.lock) to reflect the new version.

**Ensured compatibility by verifying that the application builds and existing tests (if available) pass successfully**

**No breaking changes were observed during local testing**

Please let me know if any additional checks or adjustments are needed.