### PR TITLE
Fixing Dockerfile for podman too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
 # Stage 2: Setup the Nginx Server to serve the app
-FROM nginx:stable-alpine3.17 AS production
+FROM docker.io/library/nginx:stable-alpine3.17 AS production
 COPY --from=build /app/dist /usr/share/nginx/html
 RUN echo 'server { listen 80; server_name _; root /usr/share/nginx/html;  location / { try_files $uri /index.html; } }' > /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
Your Dockerfile, while absolutely fine, is too tightened to docker only.  
You're assuming the default registry _(docker.io)_ and the default namespace _(library)_.  
With a simple line modification you can have it working without issues with docker and podman too.  
Many of us are not allowed to use docker for licensing issues (docker is not free) and others simply don't want to have it around because podman has different benefits (license, rootless, daemon free, ...).
As a CNCF suggestion it's also welcomed if you'd like to change the filename from `Dockerfile` to `Containerfile` in the future which seems to be more permissive and friendly for other engines too (lxd, containerd, ...).

