### PR TITLE
Quote relationship identifiers with spaces

### DIFF
--- a/src/utils/exportAs/dbml.js
+++ b/src/utils/exportAs/dbml.js
@@ -108,7 +108,7 @@ export function toDBML(diagram) {
       (f) => f.id === rel.endFieldId,
     );
 
-    return `Ref ${rel.name} {\n\t${quoteIdentifier(startTableName)}.${quoteIdentifier(startFieldName)} ${cardinality(rel)} ${quoteIdentifier(endTableName)}.${quoteIdentifier(endFieldName)} [ delete: ${rel.deleteConstraint.toLowerCase()}, update: ${rel.updateConstraint.toLowerCase()} ]\n}`;
+    return `Ref ${quoteIdentifier(rel.name)} {\n\t${quoteIdentifier(startTableName)}.${quoteIdentifier(startFieldName)} ${cardinality(rel)} ${quoteIdentifier(endTableName)}.${quoteIdentifier(endFieldName)} [ delete: ${rel.deleteConstraint.toLowerCase()}, update: ${rel.updateConstraint.toLowerCase()} ]\n}`;
   };
 
   let enumDefinitions = "";


### PR DESCRIPTION
**Summary:**
This PR fixes an incompatibility between exporting and parsing: relationship names containing spaces were exported without quotes, producing DBML that could not be parsed back.
(See #581)

Changes:

    Added quoteIdentifier() to relationship names.

Why:
Ensures that exported DBML is always valid and re-parsable, avoiding round-trip errors when using space-containing table names.

Tests:

    Verified round-trip (export → parse → export) produces consistent results.

fixes #586 