### PR TITLE
Fix:- Fixes SVG export compatibility issues with graphics software like Inkscape and reduces file size.

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -81,6 +81,7 @@ import { IdContext } from "../Workspace";
 import { socials } from "../../data/socials";
 import { toDBML } from "../../utils/exportAs/dbml";
 import { exportSavedData } from "../../utils/exportSavedData";
+import { optimizeSvg } from "../../utils/optimizeSvg";
 import { nanoid } from "nanoid";
 import { getTableHeight } from "../../utils/utils";
 import { deleteFromCache, STORAGE_KEY } from "../../utils/cache";
@@ -1131,12 +1132,31 @@ export default function ControlPanel({
           {
             name: "SVG",
             function: () => {
-              const filter = (node) => node.tagName !== "i";
-              toSvg(document.getElementById("canvas"), { filter: filter }).then(
+              const filter = (node) => {
+                // Filter out icon elements and other unnecessary nodes
+                if (node.tagName === "i") return false;
+                if (node.classList && node.classList.contains("semi-icon")) return false;
+                return true;
+              };
+              
+              const options = {
+                filter: filter,
+                backgroundColor: settings.mode === "dark" ? "#16161A" : "#ffffff",
+                // Optimize for smaller file size and better compatibility
+                skipFonts: true,
+                preferredFontFormat: "woff2",
+                // Ensure proper dimensions
+                width: document.getElementById("canvas").scrollWidth,
+                height: document.getElementById("canvas").scrollHeight,
+              };
+              
+              toSvg(document.getElementById("canvas"), options).then(
                 function (dataUrl) {
+                  // Optimize SVG for better compatibility and smaller size
+                  const optimizedSvg = optimizeSvg(dataUrl);
                   setExportData((prev) => ({
                     ...prev,
-                    data: dataUrl,
+                    data: optimizedSvg,
                     extension: "svg",
                   }));
                 },

--- a/src/utils/optimizeSvg.js
+++ b/src/utils/optimizeSvg.js
@@ -1,0 +1,73 @@
+/**
+ * Optimizes SVG content for better compatibility and smaller file size
+ * @param {string} svgDataUrl - The SVG data URL from html-to-image
+ * @returns {string} - Optimized SVG data URL
+ */
+export function optimizeSvg(svgDataUrl) {
+  try {
+    // Extract SVG content from data URL
+    const svgContent = atob(svgDataUrl.split(',')[1]);
+    
+    // Parse SVG
+    const parser = new DOMParser();
+    const svgDoc = parser.parseFromString(svgContent, 'image/svg+xml');
+    const svgElement = svgDoc.documentElement;
+    
+    // Remove unnecessary attributes and elements
+    const elementsToRemove = svgElement.querySelectorAll('style[data-emotion], script, .semi-icon');
+    elementsToRemove.forEach(el => el.remove());
+    
+    // Optimize inline styles - remove redundant CSS
+    const allElements = svgElement.querySelectorAll('*');
+    allElements.forEach(el => {
+      if (el.style) {
+        // Remove common redundant styles
+        el.style.removeProperty('pointer-events');
+        el.style.removeProperty('user-select');
+        el.style.removeProperty('-webkit-user-select');
+        el.style.removeProperty('cursor');
+      }
+    });
+    
+    // Set proper SVG attributes for better compatibility
+    svgElement.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    svgElement.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    
+    // Ensure viewBox is set for proper scaling
+    if (!svgElement.getAttribute('viewBox')) {
+      const width = svgElement.getAttribute('width') || '800';
+      const height = svgElement.getAttribute('height') || '600';
+      svgElement.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    }
+    
+    // Serialize back to string
+    const serializer = new XMLSerializer();
+    const optimizedSvg = serializer.serializeToString(svgElement);
+    
+    // Create new data URL
+    const optimizedDataUrl = `data:image/svg+xml;base64,${btoa(optimizedSvg)}`;
+    
+    return optimizedDataUrl;
+  } catch (error) {
+    console.warn('SVG optimization failed, returning original:', error);
+    return svgDataUrl;
+  }
+}
+
+/**
+ * Estimates the file size reduction from SVG optimization
+ * @param {string} originalSvg - Original SVG data URL
+ * @param {string} optimizedSvg - Optimized SVG data URL  
+ * @returns {object} - Size comparison object
+ */
+export function getSvgSizeComparison(originalSvg, optimizedSvg) {
+  const originalSize = originalSvg.length;
+  const optimizedSize = optimizedSvg.length;
+  const reduction = ((originalSize - optimizedSize) / originalSize * 100).toFixed(1);
+  
+  return {
+    originalSize: `${(originalSize / 1024).toFixed(1)} KB`,
+    optimizedSize: `${(optimizedSize / 1024).toFixed(1)} KB`,
+    reduction: `${reduction}%`
+  };
+}


### PR DESCRIPTION
### Problem
- SVG exports were 12MB+ for simple diagrams
- Inkscape showed blank/white files
- Poor compatibility with graphics software

## Solution
- Added SVG optimization utility with proper filtering
- Improved export options (background, dimensions, font handling)
- Removed unnecessary elements and redundant CSS
- Set proper SVG attributes for better compatibility

 fixes bug #612 

## Testing
- [x] Linting passes
- [ ] Test SVG export with simple diagram
- [ ] Verify Inkscape compatibility
- [ ] Check file size reduction

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)