### PR TITLE
Add circular type dependency detection

### DIFF
--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -200,6 +200,7 @@ const en = {
       "Duplicate type fields by name '{{fieldName}}' in type '{{typeName}}'",
     duplicate_reference: "Duplicate reference by the name '{{refName}}'",
     circular_dependency: "Circular dependency involving table '{{refName}}'",
+    circular_type_dependency: "Circular type dependency involving type '{{typeName}}'",
     timeline: "Timeline",
     priority: "Priority",
     none: "None",

--- a/src/i18n/locales/es.js
+++ b/src/i18n/locales/es.js
@@ -195,6 +195,7 @@ const es = {
       "Campos de tipo duplicados por nombre '{{fieldName}}' en el tipo '{{typeName}}'",
     duplicate_reference: "Referencia duplicada con el nombre '{{refName}}'",
     circular_dependency: "Dependencia circular involucrando la tabla '{{refName}}'",
+    circular_type_dependency: "Dependencia circular de tipos involucrando el tipo '{{typeName}}'",
     timeline: "Linea del tiempo",
     priority: "Prioridad",
     none: "Ninguno",

--- a/src/utils/issues.js
+++ b/src/utils/issues.js
@@ -202,6 +202,7 @@ export function getIssues(diagram) {
     }
   });
 
+  // Check for circular table relationships
   const visitedTables = new Set();
 
   function checkCircularRelationships(tableId, visited = []) {
@@ -227,6 +228,39 @@ export function getIssues(diagram) {
   diagram.tables.forEach((table) => {
     if (!visitedTables.has(table.id)) {
       checkCircularRelationships(table.id);
+    }
+  });
+
+  // Check for circular type dependencies
+  function checkCircularTypes(typeName, visited = []) {
+    if (visited.includes(typeName)) {
+      issues.push(
+        i18n.t("circular_type_dependency", {
+          typeName: typeName,
+        }),
+      );
+      return;
+    }
+
+    const currentType = diagram.types.find((t) => t.name === typeName);
+    if (!currentType) return;
+
+    visited.push(typeName);
+
+    currentType.fields.forEach((field) => {
+      // Check if this field references another custom type
+      const referencedType = diagram.types.find((t) => t.name === field.type);
+      if (referencedType && field.type !== typeName) {
+        checkCircularTypes(field.type, [...visited]);
+      }
+    });
+  }
+
+  const visitedTypes = new Set();
+  diagram.types.forEach((type) => {
+    if (!visitedTypes.has(type.name)) {
+      visitedTypes.add(type.name);
+      checkCircularTypes(type.name);
     }
   });
 


### PR DESCRIPTION
## Description
Adds validation to detect circular dependencies in custom types and shows proper error messages in the issues panel.

## Problem
When users create custom types that reference each other (e.g., `type_1` has a field of `type_2`, and `type_2` has a field of `type_1`), no error was shown. This could lead to invalid type structures.

## Solution
- Added `checkCircularTypes` function to detect type reference loops
- Added proper translation keys for the error message
- Shows clear error: "Circular type dependency involving type 'X'"

## How to Test
1. Go to Types tab in sidebar
2. Create `type_1` with a field of type `type_2`
3. Create `type_2` with a field of type `type_1`
4. Check Issues panel - should show circular dependency error

## Type of Change
- [x] Bug fix (adds missing validation)
- [x] Enhancement (improves user experience)

Fixes missing validation for circular type references.

FIxes Show error for circular type references #615 

