### PR TITLE
[FEAT] Add support for comments on tables and columns in PostgreSQL import

### DIFF
--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -360,6 +360,23 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
           }
         });
       }
+    } else if (e.type === "comment") {
+      if (e.target.type === "table") {
+        const table = tables.find((t) => t.name === e.target?.name?.table);
+        if (table) {
+          table.comment = e.expr.expr.value;
+        }
+      } else if (e.target.type === "column") {
+        const table = tables.find((t) => t.name === e.target?.name?.table);
+        if (table) {
+          const field = table.fields.find(
+            (f) => f.name === e.target?.name?.column?.expr?.value,
+          );
+          if (field) {
+            field.comment = e.expr.expr.value;
+          }
+        }
+      }
     }
   };
 


### PR DESCRIPTION
**fixes**: #624 

**description**:
Added comment import code for Postgres *import from SQL*

**Test**:

Used the following sql file for test

```
CREATE TABLE IF NOT EXISTS "customer identity" (
	-- main table id
	"id" INTEGER NOT NULL UNIQUE GENERATED BY DEFAULT AS IDENTITY,
	-- The alias of the username for the table 
	"pseudo name " VARCHAR(255) NOT NULL,
	PRIMARY KEY("id")
);

COMMENT ON TABLE "customer identity" IS 'the customer identity platform team main table';
COMMENT ON COLUMN "customer identity"."id" IS 'main table id';
COMMENT ON COLUMN "customer identity"."pseudo name " IS 'The alias of the username for the table ';
```

**Demonstration**:


https://github.com/user-attachments/assets/403e6401-9ce3-4f4c-8dab-9234be59f96b




