### PR TITLE
feat(validation): Add circular type dependency check

### DIFF
--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -200,6 +200,8 @@ const en = {
       "Duplicate type fields by name '{{fieldName}}' in type '{{typeName}}'",
     duplicate_reference: "Duplicate reference by the name '{{refName}}'",
     circular_dependency: "Circular dependency involving table '{{refName}}'",
+    circular_type_dependency:
+      "Circular type dependency detected in: {{typeName}}",
     timeline: "Timeline",
     priority: "Priority",
     none: "None",


### PR DESCRIPTION
**Problem:**
Users can create a circular dependency between custom types (e.g., Type A references Type B, and Type B references Type A). This structure is invalid and cannot be correctly generated in a schema but was not being flagged as an issue.

Furthermore, an initial attempt to implement this failed due to a case mismatch between how custom type names are defined (`type_a`) and how they are referenced by fields (`TYPE_A`).

**Solution:**
1.  **Implemented Circular Dependency Check:** Added a Depth First Search (DFS) algorithm within `getIssues.js` to detect cycles within the `diagram.types` graph.
2.  **Added Translation Key:** Included the new translation key `circular_type_dependency` in `en.js`.
3.  **Fixed Casing Discrepancy (Name Normalization):** Normalized all custom type names and references to uppercase within the DFS logic. This ensures the lookup works reliably regardless of the casing in the stored data, correctly identifying the circular reference.

**Validation/Testing:**
Created two custom types, `type_A` and `type_B`.
- `type_A` has a field referencing `TYPE_B`.
- `type_B` has a field referencing `TYPE_A`.

**Expected Result (Achieved):** The Issues panel now correctly displays "Issues (1)" and the message: "Circular type dependency detected in: type\_A."
<img width="957" height="826" alt="Screenshot 2025-10-10 144920" src="https://github.com/user-attachments/assets/40ae06a7-39df-4dc4-a466-20a8f11c55d5" />
