### PR TITLE
 Updated feat: use sequential visible table names ("table 1", "table 2", ...) 

### DIFF
--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -25,33 +25,44 @@ export default function DiagramContextProvider({ children }) {
         return temp;
       });
     } else {
-      setTables((prev) => [
-        ...prev,
-        {
-          id,
-          name: `table_${id}`,
-          x: transform.pan.x,
-          y: transform.pan.y,
-          locked: false,
-          fields: [
-            {
-              name: "id",
-              type: database === DB.GENERIC ? "INT" : "INTEGER",
-              default: "",
-              check: "",
-              primary: true,
-              unique: true,
-              notNull: true,
-              increment: true,
-              comment: "",
-              id: nanoid(),
-            },
-          ],
-          comment: "",
-          indices: [],
-          color: defaultBlue,
-        },
-      ]);
+      setTables((prev) => {
+        // find existing table_<number> or table <number> names and pick the next integer
+        const nums = prev
+          .map((t) => {
+            if (!t.name) return null;
+            const m = t.name.match(/^table[_ ](\d+)$/);
+            return m ? parseInt(m[1], 10) : null;
+          })
+          .filter((n) => n !== null);
+        const next = nums.length ? Math.max(...nums) + 1 : 1;
+        return [
+          ...prev,
+          {
+            id,
+            name: `table ${next}`,
+            x: transform.pan.x,
+            y: transform.pan.y,
+            locked: false,
+            fields: [
+              {
+                name: "id",
+                type: database === DB.GENERIC ? "INT" : "INTEGER",
+                default: "",
+                check: "",
+                primary: true,
+                unique: true,
+                notNull: true,
+                increment: true,
+                comment: "",
+                id: nanoid(),
+              },
+            ],
+            comment: "",
+            indices: [],
+            color: defaultBlue,
+          },
+        ];
+      });
     }
     if (addToHistory) {
       setUndoStack((prev) => [


### PR DESCRIPTION
**Summary:** Update on [BUG] #599
Change default visible table naming so newly created tables are named sequentially as
"table 1", "table 2", etc. The generator now scans existing table names that match
`/^table[_ ](\d+)$/` (underscore or space) and picks the next integer. Internal ids
remain nanoid() values; only the visible name format changed.


![2025-10-2300-10-27-ezgif com-crop](https://github.com/user-attachments/assets/5eff2bf1-103e-4e8d-b823-70c76f236dce)


**What changed**:
- Default table name for newly created tables changed from a random nanoid suffix to
  "table N" (space).
- Computation happens inside the functional setTables(...) update to avoid race conditions.
- Existing non-numeric names (e.g. `table_BnY...`) are ignored when computing the next number.

**Why**:
- Improve readability of default table names and provide predictable sequencing for new tables
  while keeping internal ids unchanged to avoid breaking other logic.
-it looks minimlistic
