### PR TITLE
Fix note autoresize loop

### DIFF
--- a/src/components/EditorCanvas/Note.jsx
+++ b/src/components/EditorCanvas/Note.jsx
@@ -78,10 +78,15 @@ export default function Note({ data, onPointerDown }) {
 
   const handleChange = (e) => {
     const textarea = document.getElementById(`note_${data.id}`);
+    if (!textarea) return;
     textarea.style.height = "0";
     textarea.style.height = textarea.scrollHeight + "px";
     const newHeight = textarea.scrollHeight + 42;
-    updateNote(data.id, { content: e.target.value, height: newHeight });
+    const updates = { content: e.target.value };
+    if (newHeight !== data.height) {
+      updates.height = newHeight;
+    }
+    updateNote(data.id, updates);
   };
 
   const handleBlur = (e) => {
@@ -181,11 +186,17 @@ export default function Note({ data, onPointerDown }) {
 
   useEffect(() => {
     const textarea = document.getElementById(`note_${data.id}`);
+    if (!textarea) return;
+
     textarea.style.height = "0";
-    textarea.style.height = textarea.scrollHeight + "px";
-    const newHeight = textarea.scrollHeight + 42;
+    const scrollHeight = textarea.scrollHeight;
+    textarea.style.height = scrollHeight + "px";
+    const newHeight = scrollHeight + 42;
+
+    if (newHeight === data.height) return;
+
     updateNote(data.id, { height: newHeight });
-  }, [data.id, updateNote]);
+  }, [data.id, data.height, updateNote]);
 
   return (
     <g
@@ -339,7 +350,10 @@ export default function Note({ data, onPointerDown }) {
           onPointerMove={(e) => {
             if (!resizing) return;
             const delta = e.movementX / (transform?.zoom || 1);
-            const next = Math.max(MIN_NOTE_WIDTH, (data.width ?? noteWidth) + delta);
+            const next = Math.max(
+              MIN_NOTE_WIDTH,
+              (data.width ?? noteWidth) + delta,
+            );
             if (next !== data.width) {
               updateNote(data.id, { width: next });
             }

--- a/src/context/NotesContext.jsx
+++ b/src/context/NotesContext.jsx
@@ -1,5 +1,10 @@
-import { createContext, useState } from "react";
-import { Action, ObjectType, defaultNoteTheme, noteWidth } from "../data/constants";
+import { createContext, useState, useCallback } from "react";
+import {
+  Action,
+  ObjectType,
+  defaultNoteTheme,
+  noteWidth,
+} from "../data/constants";
 import { useUndoRedo, useTransform, useSelect } from "../hooks";
 import { Toast } from "@douyinfe/semi-ui";
 import { useTranslation } from "react-i18next";
@@ -77,7 +82,7 @@ export default function NotesContextProvider({ children }) {
     }
   };
 
-  const updateNote = (id, values) => {
+  const updateNote = useCallback((id, values) => {
     setNotes((prev) =>
       prev.map((t) => {
         if (t.id === id) {
@@ -89,7 +94,7 @@ export default function NotesContextProvider({ children }) {
         return t;
       }),
     );
-  };
+  }, []);
 
   return (
     <NotesContext.Provider


### PR DESCRIPTION
We started seeing a runtime warning when adding note annotations: 

```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
    at Note (http://localhost:5173/src/components/EditorCanvas/Note.jsx:39:32)
    at svg
    at div
    at div
    at Canvas (http://localhost:5173/src/components/EditorCanvas/Canvas.jsx:54:17)
    at div
    at CanvasContextProvider (http://localhost:5173/src/context/CanvasContext.jsx:53:41)
    at div
    at div
    at div
    at WorkSpace (http://localhost:5173/src/components/Workspace.jsx:57:23)
    at SaveStateContextProvider (http://localhost:5173/src/context/SaveStateContext.jsx:21:52)
    at DiagramContextProvider (http://localhost:5173/src/context/DiagramContext.jsx:25:50)
    at EnumsContextProvider (http://localhost:5173/src/context/EnumsContext.jsx:24:48)
    at TypesContextProvider (http://localhost:5173/src/context/TypesContext.jsx:24:48)
    at NotesContextProvider (http://localhost:5173/src/context/NotesContext.jsx:24:48)
    at AreasContextProvider (http://localhost:5173/src/context/AreasContext.jsx:24:48)
    at TasksContextProvider (http://localhost:5173/src/context/TasksContext.jsx:20:48)
    at SelectContextProvider (http://localhost:5173/src/context/SelectContext.jsx:21:49)
    at UndoRedoContextProvider (http://localhost:5173/src/context/UndoRedoContext.jsx:27:51)
    at TransformContextProvider (http://localhost:5173/src/context/TransformContext.jsx:20:52)
    at LayoutContextProvider (http://localhost:5173/src/context/LayoutContext.jsx:20:49)
    at Editor (http://localhost:5173/src/pages/Editor.jsx:33:3)
    at RenderedRoute (http://localhost:5173/node_modules/.vite/deps/react-router-dom.js?v=1e3c90e4:4088:5)
    at Routes (http://localhost:5173/node_modules/.vite/deps/react-router-dom.js?v=1e3c90e4:4558:5)
    at Router (http://localhost:5173/node_modules/.vite/deps/react-router-dom.js?v=1e3c90e4:4501:15)
    at BrowserRouter (http://localhost:5173/node_modules/.vite/deps/react-router-dom.js?v=1e3c90e4:5247:5)
    at SettingsContextProvider (http://localhost:5173/src/context/SettingsContext.jsx:34:51)
    at App
    at LocaleProvider (http://localhost:5173/node_modules/.vite/deps/@douyinfe_semi-ui.js?v=bdce4393:95992:5)
printWarning @ chunk-KPD4VVXB.js?v=3f1e3a56:521
error @ chunk-KPD4VVXB.js?v=3f1e3a56:505
checkForNestedUpdates @ chunk-KPD4VVXB.js?v=3f1e3a56:19718
scheduleUpdateOnFiber @ chunk-KPD4VVXB.js?v=3f1e3a56:18583
dispatchSetState @ chunk-KPD4VVXB.js?v=3f1e3a56:12451
updateNote @ NotesContext.jsx:81
(anonymous) @ Note.jsx:187
commitHookEffectListMount @ chunk-KPD4VVXB.js?v=3f1e3a56:16963
commitPassiveMountOnFiber @ chunk-KPD4VVXB.js?v=3f1e3a56:18206
commitPassiveMountEffects_complete @ chunk-KPD4VVXB.js?v=3f1e3a56:18179
commitPassiveMountEffects_begin @ chunk-KPD4VVXB.js?v=3f1e3a56:18169
commitPassiveMountEffects @ chunk-KPD4VVXB.js?v=3f1e3a56:18159
flushPassiveEffectsImpl @ chunk-KPD4VVXB.js?v=3f1e3a56:19543
flushPassiveEffects @ chunk-KPD4VVXB.js?v=3f1e3a56:19500
(anonymous) @ chunk-KPD4VVXB.js?v=3f1e3a56:19381
workLoop @ chunk-KPD4VVXB.js?v=3f1e3a56:197
flushWork @ chunk-KPD4VVXB.js?v=3f1e3a56:176
performWorkUntilDeadline @ chunk-KPD4VVXB.js?v=3f1e3a56:384
```


The note component recalculated its height on mount and immediately pushed that update through context—even when the value stayed the same—so every render retriggered the effect and caused an infinite loop. This PR makes the height recalculation idempotent and memoizes `updateNote` so we stop hitting that update depth limit.