### PR TITLE
chore(examples): add SQL Server DDL import test case and README

### DIFF
--- a/examples/sqlserver/README.md
+++ b/examples/sqlserver/README.md
@@ -1,0 +1,11 @@
+# SQL Server Import Example
+
+This folder contains a sample SQL Server DDL that currently causes import errors in DrawDB.
+It can be used to reproduce and test issue #529.
+
+**File:** `employees-ddl.sql`
+
+Features included:
+- `IDENTITY` columns
+- `GO` batch separators
+- `getdate()` in CHECK constraints

--- a/examples/sqlserver/employees-ddl.sql
+++ b/examples/sqlserver/employees-ddl.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "Employees" (
+"EmployeeID" "int" IDENTITY (1, 1) NOT NULL ,
+"LastName" nvarchar (20) NOT NULL ,
+"FirstName" nvarchar (10) NOT NULL ,
+"Title" nvarchar (30) NULL ,
+"TitleOfCourtesy" nvarchar (25) NULL ,
+"BirthDate" "datetime" NULL ,
+"HireDate" "datetime" NULL ,
+"Address" nvarchar (60) NULL ,
+"City" nvarchar (15) NULL ,
+"Region" nvarchar (15) NULL ,
+"PostalCode" nvarchar (10) NULL ,
+"Country" nvarchar (15) NULL ,
+"HomePhone" nvarchar (24) NULL ,
+"Extension" nvarchar (4) NULL ,
+"Photo" "image" NULL ,
+"Notes" "ntext" NULL ,
+"ReportsTo" "int" NULL ,
+"PhotoPath" nvarchar (255) NULL ,
+CONSTRAINT "PK_Employees" PRIMARY KEY CLUSTERED
+(
+"EmployeeID"
+),
+CONSTRAINT "FK_Employees_Employees" FOREIGN KEY
+(
+"ReportsTo"
+) REFERENCES "dbo"."Employees" (
+"EmployeeID"
+),
+CONSTRAINT "CK_Birthdate" CHECK (BirthDate < getdate())
+)
+GO
+CREATE INDEX "LastName" ON "dbo"."Employees"("LastName")
+GO
+CREATE INDEX "PostalCode" ON "dbo"."Employees"("PostalCode")
+GO


### PR DESCRIPTION
This PR adds a sample SQL Server DDL under `/examples/sqlserver/` to help reproduce
the import error reported in issue #529.

The file demonstrates SQL Server–specific syntax such as `IDENTITY`, `GO`,
and `getdate()` that currently trigger parsing errors in DrawDB's import feature.

This example can be used by maintainers or contributors to test and verify
SQL Server dialect handling improvements in the future.