### PR TITLE
Fix: block canvas field deletion in read-only mode

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -434,7 +434,11 @@ export default function Table({
                 backgroundColor: "#d42020b3",
               }}
               icon={<IconMinus />}
-              onClick={() => deleteField(fieldData, tableData.id)}
+              disabled={layout.readOnly}
+              onClick={() => {
+                if (layout.readOnly) return;
+                deleteField(fieldData, tableData.id);
+              }}
             />
           ) : settings.showDataTypes ? (
             <div className="flex gap-1 items-center">


### PR DESCRIPTION
fixes #696

**Summary**
Prevent the minus button on the canvas from deleting table fields when viewing a read-only diagram. This ensures that non-editable diagram versions remain immutable and protected from accidental data loss.

**Solution**
Disable the minus button and guard the click handler whenever layout.readOnly is true, ensuring the canvas behavior matches the rest of the editor.