### PR TITLE
fix: prevent crash on invalid URI during JSON import (#561)

### DIFF
--- a/src/utils/safeFormats.js
+++ b/src/utils/safeFormats.js
@@ -1,0 +1,22 @@
+/**
+ * Custom JSON Schema format validator for URIs.
+ *
+ * @param {string} input The string to validate.
+ * @returns {boolean} True if the input is a valid URI or an empty string, false otherwise.
+ */
+export function safeUriValidator(input) {
+  if (input === "") {
+    return true;
+  }
+
+  // Trim whitespace from the input.
+  const trimmedInput = input.trim();
+
+  try {
+    // eslint-disable-next-line no-new
+    new URL(trimmedInput);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/utils/validateSchema.js
+++ b/src/utils/validateSchema.js
@@ -1,10 +1,14 @@
 import { Validator } from "jsonschema";
 import { ddbSchema, jsonSchema } from "../data/schemas";
+import { safeUriValidator } from "./safeFormats";
+
+const validator = new Validator();
+validator.customFormats.uri = safeUriValidator;
 
 export function jsonDiagramIsValid(obj) {
-  return new Validator().validate(obj, jsonSchema).valid;
+  return validator.validate(obj, jsonSchema).valid;
 }
 
 export function ddbDiagramIsValid(obj) {
-  return new Validator().validate(obj, ddbSchema).valid;
+  return validator.validate(obj, ddbSchema).valid;
 }


### PR DESCRIPTION
This PR fixes issue #561.

The JSON import flow was crashing because the default `uri` format validator inside jsonschema throws a TypeError when given an empty string or a non-URL-safe value.

This patch adds a safe custom URI validator (`safeUriValidator`) and overrides the built-in `uri` format.  
It allows empty strings, trims input, and returns false instead of throwing — preventing the app from crashing.

Tested locally:
✓ Export JSON
✓ Re-import JSON in a fresh editor tab
✓ No errors, import works correctly

Thanks!
