### PR TITLE
Fix Nepali translations for “Open Recent” and related editor tooltips

### DIFF
--- a/src/i18n/locales/ne.js
+++ b/src/i18n/locales/ne.js
@@ -13,11 +13,13 @@ const ne = {
     new: "नयाँ",
     new_window: "नयाँ विन्डो",
     open: "खोल्नुहोस्",
+    open_recent: "हालै खोलिएका",
     save: "सेभ गर्नुहोस्",
     save_as: "यो रूपमा सेभ गर्नुहोस्",
     save_as_template: "टेम्पलेट रूपमा सेभ गर्नुहोस्",
     template_saved: "टेम्पलेट सेभ गरियो!",
     rename: "नाम परिवर्तन गर्नुहोस्",
+    no_saved_diagrams: "तपाईंका सेभ गरिएका डायग्राम छैनन्।",
     delete_diagram: "डायग्राम मेटाउनुहोस्",
     are_you_sure_delete_diagram:
       "के तपाईं पक्का यो डायग्राम मेटाउन चाहनुहुन्छ? यो कार्य पुनः प्राप्त गर्न सकिँदैन।",
@@ -214,7 +216,10 @@ const ne = {
     add_relationship: "संबन्ध थप्नुहोस्",
     edit_relationship: "{{extra}} सम्बन्ध सम्पादन गर्नुहोस् {{refName}}",
     delete_relationship: "संबन्ध मेटाउनुहोस् {{refName}}",
+    didnt_find_diagram: "उफ! डायग्राम फेला परेन।",
     not_found: "फेला परेन",
+    see_all: "सबै देखाउनुहोस्",
+    versions: "संस्करणहरू",
   },
 };
 


### PR DESCRIPTION

![awefawf](https://github.com/user-attachments/assets/98b3a1a2-0976-4f8a-9e4c-0e0116bdae45)

### Add missing Nepali translations to prevent English fallbacks:

  - open_recent: “हालै खोलिएका”
  - no_saved_diagrams: “तपाईंका सेभ गरिएका डायग्राम छैनन्।”
  - see_all: “सबै देखाउनुहोस्”
  - versions: “संस्करणहरू”
  - didnt_find_diagram: “उफ! डायग्राम फेला परेन।”
 
 
![dasdgfx](https://github.com/user-attachments/assets/fc20cccc-e0c0-470a-aeed-c5926af62092)

 
Affects File menu and editor tooltips when language is set to Nepali.

Files changed: 
**src/i18n/locales/ne.js**