### PR TITLE
Fix: Prevent areFieldsCompatible from crashing when DB or field type mappings are missing

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -56,9 +56,11 @@ export function isFunction(str) {
 
 export function areFieldsCompatible(db, field1Type, field2Type) {
   const same = field1Type === field2Type;
+  const dbTypes = dbToTypes[db];
+  const fieldConfig = dbTypes?.[field1Type];
   const isCompatible =
-    dbToTypes[db][field1Type].compatibleWith &&
-    dbToTypes[db][field1Type].compatibleWith.includes(field2Type);
+    fieldConfig?.compatibleWith?.includes(field2Type) ?? false;
+
   return same || isCompatible;
 }
 


### PR DESCRIPTION
**This PR adds safeguards to the areFieldsCompatible utility to prevent runtime crashes when database or field type mappings are missing from dbToTypes. The fix improves stability when importing schemas with custom types or partially supported DB engines.**

**Issue**

The previous implementation assumed that every DB and field type exists:
```
js

dbToTypes[db][field1Type].compatibleWith.includes(field2Type);
```

When any of these were missing:

- dbToTypes[db]
- dbToTypes[db][field1Type]
- compatibleWith

DrawDB threw a runtime error:

`TypeError: Cannot read properties of undefined (reading 'compatibleWith')`

This caused schema imports to fail for:

- Custom tables
- Unknown or non-standard field types
- Partially imported or incomplete schemas
- DB engines not included in the built-in datatypes map

### Fix

The function now safely checks for missing mappings using optional chaining:

```
JavaScript

const dbTypes = dbToTypes[db];
const fieldConfig = dbTypes?.[field1Type];
const isCompatible = fieldConfig?.compatibleWith?.includes(field2Type) ?? false;
return same || isCompatible;
```
✅ No behavior change for valid field types

✅ Gracefully handles unknown types by falling back to equality check

✅ Matches DrawDB’s existing behavior of “best effort” compatibility

### Impact

Prevents app crashes during schema import and diagram loading
Improves stability for custom DBs and user-defined field types
Changes are small, isolated, and low-risk
No new dependencies or breaking changes

### _**_Testing_**_

Manual verification performed:

[x] Schema imports that previously crashed now load correctly
[x] Normal schemas behave exactly as before
[x] No regressions observed