### PR TITLE
fix: add missing Malay (ms) translation keys

### DIFF
--- a/src/i18n/locales/ms.js
+++ b/src/i18n/locales/ms.js
@@ -9,6 +9,9 @@ const ms = {
     report_bug: "Laporkan pepijat",
     import_from: "Import dari",
     import: "Import",
+    inherits: "Mewarisi",
+    merging_column_w_inherited_definition:
+      "Lajur '{{fieldName}}' dalam jadual '{{tableName}}' dengan definisi yang diwarisi akan digabungkan",
     file: "Fail",
     new: "Baru",
     new_window: "Tetingkap baru",


### PR DESCRIPTION
### Summary
Added the missing translation keys in the Malay (`ms`) locale file to ensure consistency with the English (`en`) translations.

### Details
During comparison of `en.translation` and `ms.translation`, the following keys were found in the English file but missing in the Malay file:

- `inherits`
- `merging_column_w_inherited_definition`

These keys have now been added to the Malay translation file.

### Result
- Translation files are now aligned.
- Prevents potential undefined string issues in the UI.
- Ensures smoother localization coverage for the `ms` locale.

