### PR TITLE
fix: use unique ID for index editing to resolve DBML import issue

### DIFF
--- a/src/components/EditorSidePanel/TablesTab/IndexDetails.jsx
+++ b/src/components/EditorSidePanel/TablesTab/IndexDetails.jsx
@@ -48,7 +48,7 @@ export default function IndexDetails({ data, fields, iid, tid }) {
           setRedoStack([]);
           updateTable(tid, {
             indices: table.indices.map((index) =>
-              index.id === iid
+              index.id === data.id
                 ? {
                     ...index,
                     fields: [...value],
@@ -75,7 +75,7 @@ export default function IndexDetails({ data, fields, iid, tid }) {
               onChange={(value) =>
                 updateTable(tid, {
                   indices: table.indices.map((index) =>
-                    index.id === iid
+                    index.id === data.id
                       ? {
                           ...index,
                           name: value,
@@ -137,7 +137,7 @@ export default function IndexDetails({ data, fields, iid, tid }) {
                   setRedoStack([]);
                   updateTable(tid, {
                     indices: table.indices.map((index) =>
-                      index.id === iid
+                      index.id === data.id
                         ? {
                             ...index,
                             [checkedValues.target.value]:
@@ -171,7 +171,7 @@ export default function IndexDetails({ data, fields, iid, tid }) {
                 ]);
                 setRedoStack([]);
                 updateTable(tid, {
-                  indices: table.indices.filter((e) => e.id !== iid),
+                  indices: table.indices.filter((e) => e.id !== data.id),
                 });
               }}
             >

--- a/src/components/EditorSidePanel/TablesTab/TableInfo.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableInfo.jsx
@@ -277,7 +277,7 @@ export default function TableInfo({ data }) {
                 indices: [
                   ...data.indices,
                   {
-                    id: data.indices.length,
+                    id: nanoid(),
                     name: `${data.name}_index_${data.indices.length}`,
                     unique: false,
                     fields: [],

--- a/src/utils/importFrom/dbml.js
+++ b/src/utils/importFrom/dbml.js
@@ -42,7 +42,7 @@ export function fromDBML(src) {
       for (const idx of table.indexes) {
         const parsedIndex = {};
 
-        parsedIndex.id = idx.id - 1;
+        parsedIndex.id = nanoid();
         parsedIndex.fields = idx.columns.map((x) => x.value);
         parsedIndex.name =
           idx.name ?? `${parsedTable.name}_index_${parsedIndex.id}`;


### PR DESCRIPTION
## Problem
Issue - 

https://github.com/user-attachments/assets/02580686-4104-4e46-825f-0cdc061dc46e

#773

After importing a DBML file, indices were not editable and required two clicks to delete. This was because the `IndexDetails` component was using the array index (`iid` prop passed as `k`) to identify the index for updates, but the update logic compared this array index with `index.id` (which is a unique ID). These values rarely matched for imported indices.

## Solution
- Updated `TableInfo.jsx` to pass the unique `idx.id` as the `iid` prop to `IndexDetails`.
- Updated `IndexDetails.jsx` to consistently use `data.id` (or the corrected `iid`) for identifying the index during updates and deletions.
- Removed the logic in `IndexDetails.jsx` that re-assigned IDs to array indices after deletion, ensuring unique IDs are preserved.

## Verification
- Verified that manually created indices can still be edited and deleted.
- Verified that imported indices are now correctly targeted by their unique ID.