### PR TITLE
Fix incorrect "null" default value check in checkDefault

### DIFF
--- a/src/utils/issues.js
+++ b/src/utils/issues.js
@@ -7,7 +7,7 @@ function checkDefault(field, database) {
   if (isFunction(field.default)) return true;
   if (
     !field.notNull &&
-    typeof field === "string" &&
+    typeof field.default === "string" &&
     field.default.toLowerCase() === "null"
   )
     return true;


### PR DESCRIPTION
This PR fixes a bug in checkDefault where the code was checking typeof field instead of typeof field.default. Because of that, nullable fields with a default value of "null" were being incorrectly flagged as invalid.

What i was fixed

Updated the condition to correctly check typeof field.default, allowing "null" defaults to pass validation as intended.

Verification

I reproduced the issue using a standalone script (repro_bug_standalone.js):

Before the fix: "null" defaults were incorrectly flagged.

After the fix: The check works as expected.

This brings the behavior of checkDefault back in line with how nullable fields should be handled.
fixes #779
