### PR TITLE
fix: correct typo in meta description (realtionship -> relationship)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Online database entity-realtionship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
+      content="Online database entity-relationship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
     />
 
     <meta name="robots" content="index,follow,max-image-preview:large" />
@@ -21,7 +21,7 @@
     />
     <meta
       property="og:description"
-      content="Online database entity-realtionship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
+      content="Online database entity-relationship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
     />
     <meta property="og:image" content="https://drawdb.app/hero_ss.png" />
 


### PR DESCRIPTION
## Description
Fixed a typo in `index.html` where 'realtionship' was misspelled instead of 'relationship' in the meta description tags.

## Changes
- Fixed typo in `name="description"` meta tag (line 11)
- Fixed typo in `property="og:description"` meta tag (line 24)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

closes #778 