### PR TITLE
Implement AI schema generation feature with multi-provider support #794

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -421,7 +420,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1218,7 +1216,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.12.6.tgz",
       "integrity": "sha512-rJFp7tXzawCrMWWRsjCR80dZoIkLJ/EPgPmTk3xqpc+9ntlwbkm3LUOdFmgN+pshnhiZTQBwbFqg/QbsA1Pw9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/html": "0.12.6",
         "@lexical/list": "0.12.6",
@@ -1419,7 +1416,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.12.6.tgz",
       "integrity": "sha512-HJBEazVwOe6duyHV6+vB/MS4kUBlCV05Cfcigdx8HlLLFQRWPqHrTpaxKz4jfb9ar0SlI2W1BUNbySAxMkC/HQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "lexical": "0.12.6"
       }
@@ -1450,7 +1446,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.12.6.tgz",
       "integrity": "sha512-hK5r/TD2nH5TfWSiCxy7/lh0s11qJcI1wo++PBQOR9o937pQ+/Zr/1tMOc8MnrTpl89mtmYtPfWW3f++HH1Yog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/list": "0.12.6",
         "@lexical/selection": "0.12.6",
@@ -2340,7 +2335,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2439,7 +2433,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2784,7 +2777,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -3182,7 +3174,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -3322,7 +3313,6 @@
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
       "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3673,7 +3663,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4637,7 +4626,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -5204,6 +5192,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5391,14 +5380,14 @@
       "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.12.6.tgz",
       "integrity": "sha512-Nlfjc+k9cIWpOMv7XufF0Mv09TAXSemNAuAqFLaOwTcN+RvhvYTDtVLSp9D9r+5I097fYs1Vf/UYwH2xEpkFfQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lib0": {
       "version": "0.2.114",
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -7243,7 +7232,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7432,7 +7420,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7445,7 +7432,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8953,7 +8939,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/api/ai.js
+++ b/src/api/ai.js
@@ -1,0 +1,265 @@
+import axios from "axios";
+
+/**
+ * System prompt that instructs AI models to generate database schemas
+ * in a specific JSON format compatible with DrawDB's internal structure.
+ */
+const SYSTEM_PROMPT = `
+You are a database architect. Your task is to generate a database schema based on the user's description.
+You must output strictly valid JSON format that matches the application's internal state structure.
+
+Output Structure:
+{
+  "tables": [
+    {
+      "id": 0,
+      "name": "TableName",
+      "x": 0,
+      "y": 0,
+      "fields": [
+        {
+          "id": 0,
+          "name": "id",
+          "type": "INT",
+          "primary": true,
+          "unique": true,
+          "notNull": true,
+          "increment": true
+        }
+      ],
+      "indices": []
+    }
+  ],
+  "relationships": [
+    {
+      "id": 0,
+      "name": "fk_table_other",
+      "startTableId": 0,
+      "startFieldId": 0,
+      "endTableId": 1,
+      "endFieldId": 0,
+      "cardinality": "ONE_TO_MANY",
+      "updateConstraint": "No action",
+      "deleteConstraint": "No action"
+    }
+  ]
+}
+
+Rules:
+1. Ensure Table IDs and Field IDs are integers and unique within the context.
+2. Relationships must reference valid Table IDs and Field IDs.
+3. Spread out the "x" and "y" coordinates so tables don't overlap (e.g., increment x by 300 for each table).
+4. Do not include markdown formatting (like \`\`\`json). Return raw JSON only.
+`;
+
+/**
+ * Configuration for supported AI providers and their available models.
+ * Each provider has a unique ID, display name, list of available models,
+ * and a default model that's selected when the provider is chosen.
+ */
+export const AI_PROVIDERS = {
+  OPENAI: {
+    id: "openai",
+    name: "OpenAI",
+    models: ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"],
+    defaultModel: "gpt-4o-mini",
+  },
+  ANTHROPIC: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: ["claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022", "claude-3-opus-20240229"],
+    defaultModel: "claude-3-5-sonnet-20241022",
+  },
+  GOOGLE: {
+    id: "google",
+    name: "Google AI",
+    models: ["gemini-2.0-flash", "gemini-2.5-flash", "gemini-2.5-pro", "gemini-flash-latest", "gemini-pro-latest"],
+    defaultModel: "gemini-2.0-flash",
+  },
+  GROQ: {
+    id: "groq",
+    name: "Groq",
+    models: ["llama-3.3-70b-versatile", "llama-3.1-70b-versatile", "mixtral-8x7b-32768"],
+    defaultModel: "llama-3.3-70b-versatile",
+  },
+};
+
+/**
+ * Calls OpenAI's API to generate a database schema.
+ * @param {string} apiKey - The OpenAI API key
+ * @param {string} model - The model to use (e.g., 'gpt-4o-mini')
+ * @param {string} description - User's natural language description of the database
+ * @returns {Promise<string>} The generated schema as a JSON string
+ */
+async function callOpenAI(apiKey, model, description) {
+  const response = await axios.post(
+    "https://api.openai.com/v1/chat/completions",
+    {
+      model,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: description },
+      ],
+      temperature: 0.2, // Low temperature for more consistent, structured output
+      max_tokens: 2000,
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+    }
+  );
+  return response.data.choices[0].message.content;
+}
+
+/**
+ * Calls Anthropic's Claude API to generate a database schema.
+ * @param {string} apiKey - The Anthropic API key
+ * @param {string} model - The model to use (e.g., 'claude-3-5-sonnet-20241022')
+ * @param {string} description - User's natural language description of the database
+ * @returns {Promise<string>} The generated schema as a JSON string
+ */
+async function callAnthropic(apiKey, model, description) {
+  const response = await axios.post(
+    "https://api.anthropic.com/v1/messages",
+    {
+      model,
+      max_tokens: 2000,
+      messages: [
+        {
+          role: "user",
+          // Anthropic combines system and user prompts in a single message
+          content: `${SYSTEM_PROMPT}\n\nUser request: ${description}`,
+        },
+      ],
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey, // Anthropic uses x-api-key header instead of Authorization
+        "anthropic-version": "2023-06-01",
+      },
+    }
+  );
+  return response.data.content[0].text;
+}
+
+/**
+ * Calls Google's Gemini API to generate a database schema.
+ * @param {string} apiKey - The Google AI API key
+ * @param {string} model - The model to use (e.g., 'gemini-2.0-flash')
+ * @param {string} description - User's natural language description of the database
+ * @returns {Promise<string>} The generated schema as a JSON string
+ */
+async function callGoogle(apiKey, model, description) {
+  const response = await axios.post(
+    // Google embeds the API key in the URL instead of headers
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+    {
+      contents: [
+        {
+          parts: [
+            {
+              text: `${SYSTEM_PROMPT}\n\nUser request: ${description}`,
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.2,
+        maxOutputTokens: 2000,
+      },
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  return response.data.candidates[0].content.parts[0].text;
+}
+
+/**
+ * Calls Groq's API to generate a database schema.
+ * Groq uses an OpenAI-compatible API format.
+ * @param {string} apiKey - The Groq API key
+ * @param {string} model - The model to use (e.g., 'llama-3.3-70b-versatile')
+ * @param {string} description - User's natural language description of the database
+ * @returns {Promise<string>} The generated schema as a JSON string
+ */
+async function callGroq(apiKey, model, description) {
+  const response = await axios.post(
+    "https://api.groq.com/openai/v1/chat/completions",
+    {
+      model,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: description },
+      ],
+      temperature: 0.2,
+      max_tokens: 2000,
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+    }
+  );
+  return response.data.choices[0].message.content;
+}
+
+/**
+ * Main function to generate a database schema using AI.
+ * Supports multiple AI providers and automatically handles their different API formats.
+ * 
+ * @param {string} description - Natural language description of the database (e.g., "A blog system with users and posts")
+ * @param {string} apiKey - API key for the selected provider
+ * @param {string} [provider='openai'] - AI provider to use ('openai', 'anthropic', 'google', or 'groq')
+ * @param {string|null} [model=null] - Specific model to use, or null to use the provider's default
+ * @returns {Promise<Object>} Parsed schema object with 'tables' and 'relationships' arrays
+ * @throws {Error} If the API call fails or the response cannot be parsed
+ */
+export async function generateSchema(description, apiKey, provider = "openai", model = null) {
+  try {
+    // Step 1: Determine which model to use
+    const selectedModel = model || AI_PROVIDERS[provider.toUpperCase()]?.defaultModel;
+
+    // Step 2: Call the appropriate AI provider
+    let generatedContent;
+    switch (provider.toLowerCase()) {
+      case "openai":
+        generatedContent = await callOpenAI(apiKey, selectedModel, description);
+        break;
+      case "anthropic":
+        generatedContent = await callAnthropic(apiKey, selectedModel, description);
+        break;
+      case "google":
+        generatedContent = await callGoogle(apiKey, selectedModel, description);
+        break;
+      case "groq":
+        generatedContent = await callGroq(apiKey, selectedModel, description);
+        break;
+      default:
+        throw new Error(`Unsupported provider: ${provider}`);
+    }
+
+    // Step 3: Clean up the response (remove markdown code blocks if AI added them)
+    let cleanedContent = generatedContent.trim();
+    if (cleanedContent.startsWith("```")) {
+      // Remove opening ```json and closing ```
+      cleanedContent = cleanedContent.replace(/^```(?:json)?\s*\n/, "").replace(/\n```\s*$/, "");
+    }
+
+    // Step 4: Parse the JSON and return the schema object
+    return JSON.parse(cleanedContent);
+  } catch (error) {
+    // Log the full error for debugging
+    console.error("AI Generation Error:", error?.response?.data || error);
+    
+    // Extract a user-friendly error message
+    const userFriendlyMessage = error?.response?.data?.error?.message || error.message;
+    throw new Error(`Failed to generate schema: ${userFriendlyMessage}`);
+  }
+}

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1788,6 +1788,15 @@ export default function ControlPanel({
               <IconAddNote />
             </button>
           </Tooltip>
+          <Tooltip content={t("ai_generate") || "AI Generate"} position="bottom">
+            <button
+              className="py-1 px-2 hover-2 rounded-sm flex items-center disabled:opacity-50"
+              onClick={() => setModal(MODAL.AI_GENERATE)}
+              disabled={layout.readOnly}
+            >
+              <i className="fa-solid fa-robot" />
+            </button>
+          </Tooltip>
           <Divider layout="vertical" margin="8px" />
           <Tooltip content={t("save")} position="bottom">
             <button

--- a/src/components/EditorHeader/Modal/AiGenerate.jsx
+++ b/src/components/EditorHeader/Modal/AiGenerate.jsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { TextArea, Input, Banner, Button, Spin, Select } from "@douyinfe/semi-ui";
+import { generateSchema, AI_PROVIDERS } from "../../../api/ai";
+import { useDiagram, useUndoRedo } from "../../../hooks";
+
+export default function AiGenerate({ setModal }) {
+  // User input state
+  const [prompt, setPrompt] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  
+  // AI provider configuration
+  const [provider, setProvider] = useState("openai");
+  const [model, setModel] = useState("");
+  
+  // UI state
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Diagram manipulation hooks
+  const { setTables, setRelationships } = useDiagram();
+  const { setUndoStack, setRedoStack } = useUndoRedo();
+
+  // Get the currently selected provider's configuration
+  const currentProvider = Object.values(AI_PROVIDERS).find(p => p.id === provider);
+  const availableModels = currentProvider?.models || [];
+
+  /**
+   * Handles the schema generation process
+   * 1. Validates input
+   * 2. Calls AI API
+   * 3. Processes coordinates to avoid table overlap
+   * 4. Updates the diagram
+   */
+  const handleGenerate = async () => {
+    // Validate that user has entered required fields
+    if (!prompt || !apiKey) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Call AI API to generate schema
+      const schema = await generateSchema(prompt, apiKey, provider, model);
+
+      // Intelligently position tables in a grid layout to prevent overlap
+      if (schema?.tables && Array.isArray(schema.tables)) {
+        schema.tables.forEach((table, index) => {
+          // Arrange tables in a 4-column grid, 300px apart
+          table.x = typeof table.x === "number" ? table.x : (index % 4) * 300;
+          table.y = typeof table.y === "number" ? table.y : Math.floor(index / 4) * 300;
+        });
+      }
+
+      // Update the diagram with the generated schema
+      setTables(schema.tables ?? []);
+      setRelationships(schema.relationships ?? []);
+
+      // Clear undo/redo history since this is a fresh generation
+      setUndoStack([]);
+      setRedoStack([]);
+
+      // Close the modal on success
+      setModal(0);
+    } catch (err) {
+      // Display user-friendly error message
+      setError(err.message || "Failed to generate schema");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  /**
+   * When user changes AI provider, reset the model selection
+   * since different providers have different available models
+   */
+  const handleProviderChange = (newProvider) => {
+    setProvider(newProvider);
+    setModel(""); 
+  };
+
+  /**
+   * Returns the appropriate placeholder text for API key input
+   * based on the selected provider
+   */
+  const getApiKeyPlaceholder = () => {
+    switch (provider) {
+      case "openai":
+        return "sk-...";
+      case "anthropic":
+        return "sk-ant-...";
+      case "google":
+        return "AIza...";
+      case "groq":
+        return "gsk_...";
+      default:
+        return "Enter your API key";
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && <Banner type="danger" description={error} />}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className="font-semibold mb-1">AI Provider</div>
+          <Select
+            value={provider}
+            onChange={handleProviderChange}
+            style={{ width: "100%" }}
+          >
+            {Object.values(AI_PROVIDERS).map((p) => (
+              <Select.Option key={p.id} value={p.id}>
+                {p.name}
+              </Select.Option>
+            ))}
+          </Select>
+        </div>
+
+        <div>
+          <div className="font-semibold mb-1">Model</div>
+          <Select
+            value={model || currentProvider?.defaultModel}
+            onChange={setModel}
+            style={{ width: "100%" }}
+            placeholder="Select model"
+          >
+            {availableModels.map((m) => (
+              <Select.Option key={m} value={m}>
+                {m}
+              </Select.Option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      <div>
+        <div className="font-semibold mb-1">API Key</div>
+        <Input
+          type="password"
+          placeholder={getApiKeyPlaceholder()}
+          value={apiKey}
+          onChange={setApiKey}
+        />
+        <div className="text-xs text-gray-500 mt-1">
+          Your key is never stored on our server.
+        </div>
+      </div>
+
+      <div>
+        <div className="font-semibold mb-1">Describe your database</div>
+        <TextArea
+          rows={6}
+          placeholder="E.g., An e-commerce system with users, products, orders, and reviews."
+          value={prompt}
+          onChange={setPrompt}
+        />
+      </div>
+
+      <div className="flex justify-end pt-2">
+        <Button
+          theme="solid"
+          disabled={loading || !prompt || !apiKey}
+          onClick={handleGenerate}
+        >
+          {loading ? <Spin /> : "Generate Schema"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditorHeader/Modal/Modal.jsx
+++ b/src/components/EditorHeader/Modal/Modal.jsx
@@ -40,6 +40,7 @@ import Open from "./Open";
 import Rename from "./Rename";
 import SetTableWidth from "./SetTableWidth";
 import Share from "./Share";
+import AiGenerate from "./AiGenerate";
 import { IdContext } from "../../Workspace";
 import { nanoid } from "nanoid";
 
@@ -379,6 +380,8 @@ export default function Modal({
         );
       case MODAL.SHARE:
         return <Share title={title} setModal={setModal} />;
+      case MODAL.AI_GENERATE:
+        return <AiGenerate setModal={setModal} />;
       default:
         return <></>;
     }

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -87,6 +87,7 @@ export const MODAL = {
   TABLE_WIDTH: 9,
   LANGUAGE: 10,
   SHARE: 11,
+  AI_GENERATE: 12,
 };
 
 export const STATUS = {

--- a/src/utils/modalData.js
+++ b/src/utils/modalData.js
@@ -25,6 +25,8 @@ export const getModalTitle = (modal) => {
       return i18n.t("language");
     case MODAL.SHARE:
       return i18n.t("share");
+    case MODAL.AI_GENERATE:
+      return i18n.t("ai_generate") || "AI Generate";
     default:
       return "";
   }
@@ -36,6 +38,8 @@ export const getModalWidth = (modal) => {
     case MODAL.OPEN:
     case MODAL.CODE:
     case MODAL.NEW:
+      return 740;
+    case MODAL.AI_GENERATE:
       return 740;
     default:
       return 600;


### PR DESCRIPTION
## Description
Issue - #794
Adds AI-powered text-to-diagram generation allowing users to create database schemas from natural language descriptions. Supports OpenAI, Anthropic, Google AI, and Groq.

## What's Changed
-  New AI generation modal with provider/model selection
-  Support for 4 major AI providers (OpenAI, Anthropic, Google, Groq)
-  Robot icon button in toolbar for easy access
-  Client-side API key handling (secure, never stored)
- Automatic table/relationship generation from natural language
-  Smart grid layout for generated tables

## Files Added
- `src/api/ai.js` - Core AI integration layer
- `src/components/EditorHeader/Modal/AiGenerate.jsx` - AI generation modal UI

## Files Modified
- `src/data/constants.js` - Added AI_GENERATE modal constant
- `src/components/EditorHeader/Modal/Modal.jsx` - Integrated AI modal
- `src/components/EditorHeader/ControlPanel.jsx` - Added toolbar button
- `src/utils/modalData.js` - Modal configuration

## Testing
-  ESLint: 0 errors, 0 warnings
-  Production build: Successful
- Manual testing: Verified with Google Gemini API
- 

Code quality: Full JSDoc documentation

## Example Usage
1. Click robot icon (🤖) in toolbar
2. Select AI provider and model
3. Enter API key
4. Describe database: "Create a blog with users, posts, and comments"
5. Click Generate
6. Schema appears on canvas, ready to edit

## Security
- API keys handled client-side only
- No server-side storage
- Direct communication with AI providers

## Future Enhancements
- Server-side API key storage option
- Schema refinement mode
- Append to existing diagram
- Local LLM support (Ollama)
<img width="746" height="253" alt="Screenshot 2025-12-03 at 8 18 27 PM" src="https://github.com/user-attachments/assets/3f796839-06c1-4dfd-8e4e-542d18313df5" />
<img width="1246" height="696" alt="Screenshot 2025-12-03 at 8 22 14 PM" src="https://github.com/user-attachments/assets/db5eb376-e784-448a-9e77-20c1475417fc" />
<img width="1246" height="696" alt="Screenshot 2025-12-03 at 8 21 24 PM" src="https://github.com/user-attachments/assets/efa301b1-e270-4f73-96fe-bcfe2414708d" />
