### PR TITLE
feat: add Dark/Light mode toggle (#800)

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import logo from "../assets/logo_light_160.png";
 import { SideSheet } from "@douyinfe/semi-ui";
 import { IconMenu } from "@douyinfe/semi-icons";
 import { socials } from "../data/socials";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Navbar() {
   const [openMenu, setOpenMenu] = useState(false);
@@ -17,7 +18,7 @@ export default function Navbar() {
           </Link>
           <div className="md:hidden flex gap-12">
             <Link
-              className="text-lg font-semibold hover:text-sky-800 transition-colors duration-300"
+              className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 hover:text-sky-800 dark:hover:text-sky-400 transition-colors duration-300"
               onClick={() =>
                 document
                   .getElementById("features")
@@ -28,24 +29,25 @@ export default function Navbar() {
             </Link>
             <Link
               to="/editor"
-              className="text-lg font-semibold hover:text-sky-800 transition-colors duration-300"
+              className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 hover:text-sky-800 dark:hover:text-sky-400 transition-colors duration-300"
             >
               Editor
             </Link>
             <Link
               to="/templates"
-              className="text-lg font-semibold hover:text-sky-800 transition-colors duration-300"
+              className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 hover:text-sky-800 dark:hover:text-sky-400 transition-colors duration-300"
             >
               Templates
             </Link>
             <Link
               to={socials.docs}
-              className="text-lg font-semibold hover:text-sky-800 transition-colors duration-300"
+              className="text-lg font-semibold text-zinc-800 dark:text-zinc-200 hover:text-sky-800 dark:hover:text-sky-400 transition-colors duration-300"
             >
               Docs
             </Link>
           </div>
-          <div className="md:hidden block space-x-3 ms-12">
+          <div className="md:hidden flex items-center space-x-3 ms-12">
+            <ThemeToggle />
             <a
               title="Jump to Github"
               className="px-2 py-2 hover:opacity-60 transition-all duration-300 rounded-full text-2xl"
@@ -75,12 +77,15 @@ export default function Navbar() {
             </a>
           </div>
         </div>
-        <button
-          onClick={() => setOpenMenu((prev) => !prev)}
-          className="hidden md:inline-block h-[24px]"
-        >
-          <IconMenu size="extra-large" />
-        </button>
+        <div className="hidden md:flex items-center space-x-2">
+          <ThemeToggle />
+          <button
+            onClick={() => setOpenMenu((prev) => !prev)}
+            className="h-[24px]"
+          >
+            <IconMenu size="extra-large" />
+          </button>
+        </div>
       </div>
       <hr />
       <SideSheet
@@ -92,7 +97,7 @@ export default function Navbar() {
         width={window.innerWidth}
       >
         <Link
-          className="hover:bg-zinc-100 block p-3 text-base font-semibold"
+          className="hover:bg-zinc-100 dark:hover:bg-zinc-700 block p-3 text-base font-semibold"
           onClick={() => {
             document
               .getElementById("features")
@@ -105,21 +110,21 @@ export default function Navbar() {
         <hr />
         <Link
           to="/editor"
-          className="hover:bg-zinc-100 block p-3 text-base font-semibold"
+          className="hover:bg-zinc-100 dark:hover:bg-zinc-700 block p-3 text-base font-semibold"
         >
           Editor
         </Link>
         <hr />
         <Link
           to="/templates"
-          className="hover:bg-zinc-100 block p-3 text-base font-semibold"
+          className="hover:bg-zinc-100 dark:hover:bg-zinc-700 block p-3 text-base font-semibold"
         >
           Templates
         </Link>
         <hr />
         <Link
           to={socials.docs}
-          className="hover:bg-zinc-100 block p-3 text-base font-semibold"
+          className="hover:bg-zinc-100 dark:hover:bg-zinc-700 block p-3 text-base font-semibold"
         >
           Docs
         </Link>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,25 @@
+import { IconSun, IconMoon } from "@douyinfe/semi-icons";
+import { Button } from "@douyinfe/semi-ui";
+import { useSettings } from "../hooks";
+
+export default function ThemeToggle() {
+  const { settings, setSettings } = useSettings();
+
+  const toggleTheme = () => {
+    setSettings(prev => ({
+      ...prev,
+      mode: prev.mode === "light" ? "dark" : "light"
+    }));
+  };
+
+  return (
+    <Button
+      icon={settings.mode === "light" ? <IconMoon /> : <IconSun />}
+      onClick={toggleTheme}
+      theme="borderless"
+      size="large"
+      className="hover:opacity-60 transition-all duration-300"
+      title={`Switch to ${settings.mode === "light" ? "dark" : "light"} mode`}
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,11 @@
   background-size: 20px 20px;
 }
 
+[theme-mode="dark"] .bg-dots {
+  background-color: rgb(39, 39, 42);
+  background-image: radial-gradient(rgb(118, 118, 209) 1px, rgb(39, 39, 42) 1px);
+}
+
 .sliding-vertical span {
   animation: top-to-bottom 9s linear infinite 0s;
   -ms-animation: top-to-bottom 9s linear infinite 0s;

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -18,6 +18,7 @@ import axios from "axios";
 import { languages } from "../i18n/i18n";
 import { Tweet } from "react-tweet";
 import { socials } from "../data/socials";
+import { useThemedPage } from "../hooks";
 
 function shortenNumber(number) {
   if (number < 1000) return number;
@@ -28,6 +29,7 @@ function shortenNumber(number) {
 
 export default function LandingPage() {
   const [stats, setStats] = useState({ stars: 18000, forks: 1200 });
+  useThemedPage();
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -36,7 +38,6 @@ export default function LandingPage() {
         .then((res) => setStats(res.data));
     };
 
-    document.body.setAttribute("theme-mode", "light");
     document.title =
       "drawDB | Online database diagram editor and SQL generator";
 
@@ -44,8 +45,8 @@ export default function LandingPage() {
   }, []);
 
   return (
-    <div>
-      <div className="flex flex-col h-screen bg-zinc-100">
+    <div className="theme">
+      <div className="flex flex-col h-screen bg-zinc-100 dark:bg-zinc-900">
         <div className="text-white font-semibold py-1 text-sm text-center bg-linear-to-r from-[#12495e] from-10% via-slate-500 to-[#12495e]" />
 
         <FadeIn duration={0.6}>
@@ -53,12 +54,12 @@ export default function LandingPage() {
         </FadeIn>
 
         {/* Hero section */}
-        <div className="flex-1 flex-col relative mx-4 md:mx-0 mb-4 rounded-3xl bg-white">
+        <div className="flex-1 flex-col relative mx-4 md:mx-0 mb-4 rounded-3xl bg-white dark:bg-zinc-800">
           <div className="h-full md:hidden">
             <SimpleCanvas diagram={diagram} zoom={0.85} />
           </div>
           <div className="hidden md:block h-full bg-dots" />
-          <div className="absolute left-12 w-[45%] top-[50%] translate-y-[-54%] md:left-[50%] md:translate-x-[-50%] p-8 md:p-3 md:w-full text-zinc-800">
+          <div className="absolute left-12 w-[45%] top-[50%] translate-y-[-54%] md:left-[50%] md:translate-x-[-50%] p-8 md:p-3 md:w-full text-zinc-800 dark:text-zinc-200">
             <FadeIn duration={0.75}>
               <div className="md:px-3">
                 <h1 className="text-[42px] md:text-3xl font-bold tracking-wide bg-linear-to-r from-sky-900 from-10% via-slate-500 to-[#12495e] inline-block text-transparent bg-clip-text">
@@ -81,7 +82,7 @@ export default function LandingPage() {
             </FadeIn>
             <div className="mt-4 font-semibold md:mt-12">
               <button
-                className="py-3 mb-4 xl:mb-0 mr-4 transition-all duration-300 bg-white border rounded-full shadow-lg px-9 border-zinc-200 hover:bg-zinc-100 cursor-pointer"
+                className="py-3 mb-4 xl:mb-0 mr-4 transition-all duration-300 bg-white dark:bg-zinc-700 border rounded-full shadow-lg px-9 border-zinc-200 dark:border-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-600 cursor-pointer text-zinc-800 dark:text-zinc-200"
                 onClick={() =>
                   document
                     .getElementById("learn-more")
@@ -103,7 +104,7 @@ export default function LandingPage() {
 
       {/* Learn more */}
       <div id="learn-more">
-        <div className="bg-zinc-100 py-10 px-28 md:px-8">
+        <div className="bg-zinc-100 dark:bg-zinc-900 py-10 px-28 md:px-8">
           {/* Supported by */}
           <div className="text-center mb-16">
             <div className="text-2xl md:text-xl font-bold text-sky-800 mb-8">
@@ -127,8 +128,8 @@ export default function LandingPage() {
               </a>
             </div>
           </div>
-          <div className="mt-16 w-[75%] text-center sm:w-full mx-auto shadow-xs rounded-2xl border p-6 bg-white space-y-3 mb-12">
-            <div className="text-lg font-medium">
+          <div className="mt-16 w-[75%] text-center sm:w-full mx-auto shadow-xs rounded-2xl border border-zinc-200 dark:border-zinc-700 p-6 bg-white dark:bg-zinc-800 space-y-3 mb-12">
+            <div className="text-lg font-medium text-zinc-800 dark:text-zinc-200">
               Build diagrams with a few clicks, see the full picture, export SQL
               scripts, customize your editor, and more.
             </div>
@@ -136,31 +137,31 @@ export default function LandingPage() {
           </div>
           <div className="flex justify-center items-center gap-28 md:block">
             <div className="text-center mb-4">
-              <div className="text-5xl md:text-3xl font-bold text-sky-800">
+              <div className="text-5xl md:text-3xl font-bold text-sky-800 dark:text-sky-400">
                 {shortenNumber(stats.stars)}
               </div>
-              <div className="ms-1 mt-1 font-medium tracking-wide">
+              <div className="ms-1 mt-1 font-medium tracking-wide text-zinc-700 dark:text-zinc-300">
                 GitHub stars
               </div>
             </div>
             <div className="text-center mb-4">
-              <div className="text-5xl md:text-3xl font-bold text-sky-800">
+              <div className="text-5xl md:text-3xl font-bold text-sky-800 dark:text-sky-400">
                 {shortenNumber(stats.forks)}
               </div>
-              <div className="ms-1 mt-1 font-medium tracking-wide">
+              <div className="ms-1 mt-1 font-medium tracking-wide text-zinc-700 dark:text-zinc-300">
                 GitHub forks
               </div>
             </div>
             <div className="text-center mb-4">
-              <div className="text-5xl md:text-3xl font-bold text-sky-800">
+              <div className="text-5xl md:text-3xl font-bold text-sky-800 dark:text-sky-400">
                 {shortenNumber(languages.length)}
               </div>
-              <div className="ms-1 mt-1 font-medium tracking-wide">
+              <div className="ms-1 mt-1 font-medium tracking-wide text-zinc-700 dark:text-zinc-300">
                 Languages
               </div>
             </div>
           </div>
-          <div className="text-lg font-medium text-center mt-12 mb-6">
+          <div className="text-lg font-medium text-center mt-12 mb-6 text-zinc-800 dark:text-zinc-200">
             Design for your database
           </div>
           <div className="grid grid-cols-3 place-items-center sm:grid-cols-1 sm:gap-10">
@@ -189,24 +190,24 @@ export default function LandingPage() {
       </div>
 
       {/* Features */}
-      <div id="features" className="py-8 px-36 md:px-8">
+      <div id="features" className="py-8 px-36 md:px-8 theme">
         <FadeIn duration={1}>
-          <div className="text-base font-medium text-center text-sky-900">
+          <div className="text-base font-medium text-center text-sky-900 dark:text-sky-400">
             More than just an editor
           </div>
-          <div className="text-2xl mt-1 font-medium text-center">
+          <div className="text-2xl mt-1 font-medium text-center text-zinc-800 dark:text-zinc-200">
             What drawDB has to offer
           </div>
           <div className="grid grid-cols-3 gap-8 mt-10 md:grid-cols-2 sm:grid-cols-1">
             {features.map((f, i) => (
               <div
                 key={"feature" + i}
-                className="flex rounded-xl hover:bg-zinc-100 border border-zinc-100 shadow-xs hover:-translate-y-2 transition-all duration-300"
+                className="flex rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-700 border border-zinc-100 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-xs hover:-translate-y-2 transition-all duration-300"
               >
-                <div className="bg-sky-700 px-0.5 rounded-l-xl" />
-                <div className="px-8 py-4 ">
-                  <div className="text-lg font-semibold mb-3">{f.title}</div>
-                  {f.content}
+                <div className="bg-sky-700 dark:bg-sky-600 px-0.5 rounded-l-xl" />
+                <div className="px-8 py-4">
+                  <div className="text-lg font-semibold mb-3 text-zinc-800 dark:text-zinc-200">{f.title}</div>
+                  <div className="text-zinc-700 dark:text-zinc-300">{f.content}</div>
                   <div className="mt-2 text-xs opacity-60">{f.footer}</div>
                 </div>
               </div>
@@ -216,8 +217,8 @@ export default function LandingPage() {
       </div>
 
       {/* Tweets */}
-      <div className="px-40 mt-6 md:px-8">
-        <div className="text-center text-2xl md:text-xl font-medium">
+      <div className="px-40 mt-6 md:px-8 theme">
+        <div className="text-center text-2xl md:text-xl font-medium text-zinc-800 dark:text-zinc-200">
           What the internet says about us
         </div>
         <div
@@ -244,11 +245,11 @@ export default function LandingPage() {
           fill="#f4f4f5"
         />
       </svg>
-      <div className="bg-zinc-100 py-8 px-32 md:px-8">
-        <div className="mt-4 mb-2 text-2xl font-bold text-center">
+      <div className="bg-zinc-100 dark:bg-zinc-900 py-8 px-32 md:px-8">
+        <div className="mt-4 mb-2 text-2xl font-bold text-center text-zinc-800 dark:text-zinc-200">
           Reach out to us
         </div>
-        <div className="text-lg text-center mb-4">
+        <div className="text-lg text-center mb-4 text-zinc-700 dark:text-zinc-300">
           We love hearing from you. Join our community on Discord, GitHub, and
           X.
         </div>
@@ -300,7 +301,7 @@ export default function LandingPage() {
         browser make sure to back up your data.
       </div>
       <hr className="border-zinc-300" />
-      <div className="text-center text-sm py-3">
+      <div className="text-center text-sm py-3 theme">
         &copy; {new Date().getFullYear()} <strong>drawDB</strong> - All rights reserved.
       </div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ export default {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
+  darkMode: ['selector', '[theme-mode="dark"]'],
   theme: {
     screens: {
       '3xl': {'max': '2047px'},


### PR DESCRIPTION
This PR implements the Dark/Light mode toggle feature requested in #800
, allowing users to switch themes for improved accessibility and comfort.

Problem:

The application currently lacks a theme toggle.

Users cannot switch between dark and light modes, limiting personalization and causing potential discomfort in low-light or high-light environments.

Users who prefer dark mode for accessibility, eye strain reduction, or night-time use cannot apply their preference.

Solution Implemented:

ThemeToggle Component:

Switches instantly between dark and light modes.

Stores user preference in localStorage.

Navbar Integration:

Toggle added to both desktop and mobile navbars.

Navbar links and menu 
<img width="1510" height="819" alt="Screenshot 2025-12-05 at 1 34 32 AM" src="https://github.com/user-attachments/assets/a2d4ec16-a032-4d4c-87a5-e7de94fd64ea" />

