### PR TITLE
fix (relashionship label ) : offset for the label Y position to avoid label overlap in flat connections

### DIFF
--- a/src/components/EditorCanvas/Relationship.jsx
+++ b/src/components/EditorCanvas/Relationship.jsx
@@ -86,6 +86,10 @@ export default function Relationship({ data }) {
     );
     cardinalityEndX = point2.x;
     cardinalityEndY = point2.y;
+
+    if (Math.abs(cardinalityStartY - cardinalityEndY) < labelFontSize) {
+      labelY -= labelFontSize
+    }
   }
 
   const edit = () => {


### PR DESCRIPTION
<img width="480" height="270" alt="Screenshot From 2026-01-18 12-47-04" src="https://github.com/user-attachments/assets/f5f3bc07-982f-4e0f-9926-ea3369eae13e" />
<img width="480" height="270" alt="Screenshot From 2026-01-18 12-47-13" src="https://github.com/user-attachments/assets/3f28af9b-dd95-4b9e-88eb-ce9e1d3b73a2" />
