### PR TITLE
Fix import JSON missing type

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -916,7 +916,10 @@ export default function ControlPanel({
       import_from: {
         children: [
           {
-            function: fileImport,
+            function: () => {
+              setModal(MODAL.IMPORT);
+              setImportFrom(IMPORT_FROM.JSON);
+            },
             name: "JSON",
             disabled: layout.readOnly,
           },


### PR DESCRIPTION
Select impot DBML and close,
Then select import JSON always show DBML 
<img width="682" height="283" alt="图片" src="https://github.com/user-attachments/assets/a02cedca-81e2-4967-8786-9d78947d9651" />
