### PR TITLE
Replace node-sql-parser with sqlparser-ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@douyinfe/semi-ui": "^2.77.1",
+        "@guanmingchiu/sqlparser-ts": "^0.61.1",
         "@lexical/react": "^0.12.5",
         "@monaco-editor/react": "^4.7.0",
         "@vercel/analytics": "^1.2.2",
@@ -31,8 +32,6 @@
         "lodash": "^4.17.23",
         "luxon": "^3.7.1",
         "nanoid": "^5.1.5",
-        "node-sql-parser": "^5.4.0",
-        "oracle-sql-parser": "^0.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hotkeys-hook": "^4.4.1",
@@ -54,7 +53,8 @@
         "postcss": "^8.4.32",
         "prettier": "3.2.5",
         "tailwindcss": "^4.0.14",
-        "vite": "^6.4.1"
+        "vite": "^6.4.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1110,6 +1110,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@guanmingchiu/sqlparser-ts": {
+      "version": "0.61.1",
+      "resolved": "https://registry.npmjs.org/@guanmingchiu/sqlparser-ts/-/sqlparser-ts-0.61.1.tgz",
+      "integrity": "sha512-5RA05UHDkcm4cyhBNz2oJqU+8+fhCZvseSGtAvuVcwM1EEh2FfRaU1qdPygpriGqsQRT3Cn1PK5YShJffQjmXg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1861,6 +1870,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -2251,6 +2267,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2259,6 +2286,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2309,12 +2343,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
       "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/pegjs": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
-      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -2426,6 +2454,117 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -2646,6 +2785,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -2736,15 +2885,6 @@
       "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
       "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
       "license": "MIT"
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2898,6 +3038,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3501,6 +3651,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3978,6 +4135,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -5741,9 +5908,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6905,19 +7072,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-sql-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
-      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/pegjs": "^0.10.0",
-        "big-integer": "^1.6.48"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7025,6 +7179,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7052,12 +7217,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/oracle-sql-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/oracle-sql-parser/-/oracle-sql-parser-0.1.0.tgz",
-      "integrity": "sha512-8MLYOJIKaOY1cWvnMFuYPxWcDH5GfmJMh/f1Tyow0bydC31heO+eSoexZW+NJBSdK87lNJl8nsQ/SY//ZGOwcQ==",
-      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -7193,6 +7352,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8194,6 +8360,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -8223,6 +8396,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -8237,6 +8417,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -8532,21 +8719,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -8991,6 +9205,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -9110,6 +9402,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dbml/core": "^3.13.9",
@@ -15,6 +16,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@douyinfe/semi-ui": "^2.77.1",
+    "@guanmingchiu/sqlparser-ts": "^0.61.1",
     "@lexical/react": "^0.12.5",
     "@monaco-editor/react": "^4.7.0",
     "@vercel/analytics": "^1.2.2",
@@ -33,8 +35,6 @@
     "lodash": "^4.17.23",
     "luxon": "^3.7.1",
     "nanoid": "^5.1.5",
-    "node-sql-parser": "^5.4.0",
-    "oracle-sql-parser": "^0.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hotkeys-hook": "^4.4.1",
@@ -56,6 +56,7 @@
     "postcss": "^8.4.32",
     "prettier": "3.2.5",
     "tailwindcss": "^4.0.14",
-    "vite": "^6.4.1"
+    "vite": "^6.4.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/utils/importSQL/__tests__/mariadb.test.js
+++ b/src/utils/importSQL/__tests__/mariadb.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@guanmingchiu/sqlparser-ts";
+import { fromMariaDB } from "../mariadb";
+import { DB } from "../../../data/constants";
+
+// MariaDB uses MySQL dialect in sqlparser-ts
+function parseMariaDB(sql) {
+  return parse(sql, "mysql");
+}
+
+describe("fromMariaDB", () => {
+  it("parses a basic CREATE TABLE", () => {
+    const ast = parseMariaDB(
+      "CREATE TABLE users (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255) NOT NULL);",
+    );
+    const result = fromMariaDB(ast, DB.MARIADB);
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[0].increment).toBe(true);
+    expect(result.tables[0].fields[1].notNull).toBe(true);
+  });
+
+  it("parses FOREIGN KEY constraints", () => {
+    const ast = parseMariaDB(`
+      CREATE TABLE departments (id INT PRIMARY KEY);
+      CREATE TABLE users (
+        id INT PRIMARY KEY,
+        dept_id INT,
+        FOREIGN KEY (dept_id) REFERENCES departments(id) ON DELETE CASCADE ON UPDATE NO ACTION
+      );
+    `);
+    const result = fromMariaDB(ast, DB.MARIADB);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Cascade");
+    expect(result.relationships[0].updateConstraint).toBe("No action");
+  });
+
+  it("parses table comments", () => {
+    const ast = parseMariaDB(
+      "CREATE TABLE users (id INT) COMMENT = 'User table';",
+    );
+    const result = fromMariaDB(ast, DB.MARIADB);
+
+    expect(result.tables[0].comment).toBe("User table");
+  });
+
+  it("parses ALTER TABLE ADD FOREIGN KEY", () => {
+    const ast = parseMariaDB(`
+      CREATE TABLE a (id INT PRIMARY KEY);
+      CREATE TABLE b (id INT PRIMARY KEY, a_id INT);
+      ALTER TABLE b ADD CONSTRAINT fk_a FOREIGN KEY (a_id) REFERENCES a(id);
+    `);
+    const result = fromMariaDB(ast, DB.MARIADB);
+
+    expect(result.relationships).toHaveLength(1);
+  });
+
+  it("parses CREATE INDEX", () => {
+    const ast = parseMariaDB(`
+      CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255));
+      CREATE INDEX idx_email ON users (email);
+    `);
+    const result = fromMariaDB(ast, DB.MARIADB);
+
+    expect(result.tables[0].indices).toHaveLength(1);
+    expect(result.tables[0].indices[0].unique).toBe(false);
+  });
+});

--- a/src/utils/importSQL/__tests__/mssql.test.js
+++ b/src/utils/importSQL/__tests__/mssql.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@guanmingchiu/sqlparser-ts";
+import { fromMSSQL } from "../mssql";
+import { DB } from "../../../data/constants";
+
+function parseMSSQL(sql) {
+  return parse(sql, "mssql");
+}
+
+describe("fromMSSQL", () => {
+  it("parses a basic CREATE TABLE", () => {
+    const ast = parseMSSQL(
+      "CREATE TABLE users (id INT PRIMARY KEY, name NVARCHAR(100));",
+    );
+    const result = fromMSSQL(ast, DB.MSSQL);
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0].name).toBe("users");
+    expect(result.tables[0].fields).toHaveLength(2);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+  });
+
+  it("parses IDENTITY columns", () => {
+    const ast = parseMSSQL(
+      "CREATE TABLE users (id INT IDENTITY(1,1) PRIMARY KEY);",
+    );
+    const result = fromMSSQL(ast, DB.MSSQL);
+
+    expect(result.tables[0].fields[0].increment).toBe(true);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+  });
+
+  it("parses FOREIGN KEY constraints", () => {
+    const ast = parseMSSQL(`
+      CREATE TABLE departments (id INT PRIMARY KEY);
+      CREATE TABLE users (
+        id INT PRIMARY KEY,
+        dept_id INT,
+        CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments(id) ON DELETE CASCADE
+      );
+    `);
+    const result = fromMSSQL(ast, DB.MSSQL);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Cascade");
+  });
+
+  it("parses ALTER TABLE ADD FOREIGN KEY", () => {
+    const ast = parseMSSQL(`
+      CREATE TABLE a (id INT PRIMARY KEY);
+      CREATE TABLE b (id INT PRIMARY KEY, a_id INT);
+      ALTER TABLE b ADD CONSTRAINT fk_a FOREIGN KEY (a_id) REFERENCES a(id);
+    `);
+    const result = fromMSSQL(ast, DB.MSSQL);
+
+    expect(result.relationships).toHaveLength(1);
+  });
+
+  it("parses CREATE INDEX", () => {
+    const ast = parseMSSQL(`
+      CREATE TABLE users (id INT PRIMARY KEY, email NVARCHAR(255));
+      CREATE UNIQUE INDEX idx_email ON users (email);
+    `);
+    const result = fromMSSQL(ast, DB.MSSQL);
+
+    expect(result.tables[0].indices).toHaveLength(1);
+    expect(result.tables[0].indices[0].unique).toBe(true);
+  });
+
+  it("maps types to GENERIC affinity", () => {
+    const ast = parseMSSQL(
+      "CREATE TABLE t (a BIT, b NCHAR(10));",
+    );
+    const result = fromMSSQL(ast, DB.GENERIC);
+
+    expect(result.tables[0].fields[0].type).toBe("BOOLEAN");
+  });
+});

--- a/src/utils/importSQL/__tests__/mysql.test.js
+++ b/src/utils/importSQL/__tests__/mysql.test.js
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@guanmingchiu/sqlparser-ts";
+import { fromMySQL } from "../mysql";
+import { DB } from "../../../data/constants";
+
+function parseMySQL(sql) {
+  return parse(sql, "mysql");
+}
+
+describe("fromMySQL", () => {
+  it("parses a basic CREATE TABLE", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL);",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0].name).toBe("users");
+    expect(result.tables[0].fields).toHaveLength(2);
+
+    const idField = result.tables[0].fields[0];
+    expect(idField.name).toBe("id");
+    expect(idField.primary).toBe(true);
+
+    const nameField = result.tables[0].fields[1];
+    expect(nameField.name).toBe("name");
+    expect(nameField.notNull).toBe(true);
+  });
+
+  it("parses AUTO_INCREMENT columns", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (id INT PRIMARY KEY AUTO_INCREMENT);",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].increment).toBe(true);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+  });
+
+  it("parses UNIQUE columns", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (email VARCHAR(100) UNIQUE);",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].unique).toBe(true);
+  });
+
+  it("parses DEFAULT values", () => {
+    const ast = parseMySQL(`
+      CREATE TABLE users (
+        status VARCHAR(20) DEFAULT 'active',
+        count INT DEFAULT 0,
+        ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].default).toBe("active");
+    expect(result.tables[0].fields[1].default).toBe("0");
+    expect(result.tables[0].fields[2].default).toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("parses CHECK constraints", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (age INT CHECK (age > 0));",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].check).toContain(">");
+  });
+
+  it("parses ENUM types", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (status ENUM('active', 'inactive'));",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].values).toEqual(["active", "inactive"]);
+  });
+
+  it("parses column comments", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (id INT COMMENT 'primary key');",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].comment).toBe("primary key");
+  });
+
+  it("parses table comments", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (id INT) COMMENT = 'User accounts';",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].comment).toBe("User accounts");
+  });
+
+  it("parses VARCHAR with size", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (name VARCHAR(255));",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].size).toBe("255");
+  });
+
+  it("parses DECIMAL with precision and scale", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE products (price DECIMAL(10,2));",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].size).toBe("10,2");
+  });
+
+  it("parses PRIMARY KEY constraint", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE users (id INT, name VARCHAR(50), PRIMARY KEY (id));",
+    );
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[1].primary).toBe(false);
+  });
+
+  it("parses FOREIGN KEY constraints", () => {
+    const ast = parseMySQL(`
+      CREATE TABLE departments (id INT PRIMARY KEY, name VARCHAR(100));
+      CREATE TABLE users (
+        id INT PRIMARY KEY,
+        dept_id INT,
+        CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments(id) ON DELETE CASCADE ON UPDATE SET NULL
+      );
+    `);
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables).toHaveLength(2);
+    expect(result.relationships).toHaveLength(1);
+
+    const rel = result.relationships[0];
+    expect(rel.startTableId).toBe(result.tables[1].id);
+    expect(rel.endTableId).toBe(result.tables[0].id);
+    expect(rel.deleteConstraint).toBe("Cascade");
+    expect(rel.updateConstraint).toBe("Set null");
+  });
+
+  it("parses ALTER TABLE ADD FOREIGN KEY", () => {
+    const ast = parseMySQL(`
+      CREATE TABLE customers (id INT PRIMARY KEY);
+      CREATE TABLE orders (id INT PRIMARY KEY, customer_id INT);
+      ALTER TABLE orders ADD CONSTRAINT fk_cust FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;
+    `);
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Cascade");
+  });
+
+  it("parses CREATE INDEX", () => {
+    const ast = parseMySQL(`
+      CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255));
+      CREATE UNIQUE INDEX idx_email ON users (email);
+    `);
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables[0].indices).toHaveLength(1);
+    expect(result.tables[0].indices[0].name).toBe("idx_email");
+    expect(result.tables[0].indices[0].unique).toBe(true);
+    expect(result.tables[0].indices[0].fields).toEqual(["email"]);
+  });
+
+  it("maps types to GENERIC affinity", () => {
+    const ast = parseMySQL(
+      "CREATE TABLE t (a TINYINT, b MEDIUMINT, c BIT);",
+    );
+    const result = fromMySQL(ast, DB.GENERIC);
+
+    expect(result.tables[0].fields[0].type).toBe("SMALLINT");
+    expect(result.tables[0].fields[1].type).toBe("INTEGER");
+    expect(result.tables[0].fields[2].type).toBe("BOOLEAN");
+  });
+
+  it("handles multiple tables and relationships", () => {
+    const ast = parseMySQL(`
+      CREATE TABLE a (id INT PRIMARY KEY);
+      CREATE TABLE b (id INT PRIMARY KEY, a_id INT, FOREIGN KEY (a_id) REFERENCES a(id));
+      CREATE TABLE c (id INT PRIMARY KEY, b_id INT, FOREIGN KEY (b_id) REFERENCES b(id));
+    `);
+    const result = fromMySQL(ast, DB.MYSQL);
+
+    expect(result.tables).toHaveLength(3);
+    expect(result.relationships).toHaveLength(2);
+  });
+});

--- a/src/utils/importSQL/__tests__/oraclesql.test.js
+++ b/src/utils/importSQL/__tests__/oraclesql.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@guanmingchiu/sqlparser-ts";
+import { fromOracleSQL } from "../oraclesql";
+import { DB } from "../../../data/constants";
+
+function parseOracle(sql) {
+  return parse(sql, "oracle");
+}
+
+describe("fromOracleSQL", () => {
+  it("parses a basic CREATE TABLE with Oracle types", () => {
+    const ast = parseOracle(
+      "CREATE TABLE employees (id NUMBER(10) PRIMARY KEY, name VARCHAR2(100) NOT NULL);",
+    );
+    const result = fromOracleSQL(ast, DB.ORACLESQL);
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0].name).toBe("employees");
+    expect(result.tables[0].fields).toHaveLength(2);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[0].size).toBe("10");
+    expect(result.tables[0].fields[1].notNull).toBe(true);
+    expect(result.tables[0].fields[1].size).toBe("100");
+  });
+
+  it("parses FOREIGN KEY constraints", () => {
+    const ast = parseOracle(`
+      CREATE TABLE departments (id NUMBER(10) PRIMARY KEY, name VARCHAR2(100));
+      CREATE TABLE employees (
+        id NUMBER(10) PRIMARY KEY,
+        dept_id NUMBER(10),
+        CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments(id) ON DELETE CASCADE
+      );
+    `);
+    const result = fromOracleSQL(ast, DB.ORACLESQL);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Cascade");
+  });
+
+  it("parses PRIMARY KEY constraint", () => {
+    const ast = parseOracle(
+      "CREATE TABLE t (a NUMBER(10), b VARCHAR2(50), PRIMARY KEY (a));",
+    );
+    const result = fromOracleSQL(ast, DB.ORACLESQL);
+
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[1].primary).toBe(false);
+  });
+});

--- a/src/utils/importSQL/__tests__/postgres.test.js
+++ b/src/utils/importSQL/__tests__/postgres.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@guanmingchiu/sqlparser-ts";
+import { fromPostgres } from "../postgres";
+import { DB } from "../../../data/constants";
+
+function parsePg(sql) {
+  return parse(sql, "postgresql");
+}
+
+describe("fromPostgres", () => {
+  it("parses a basic CREATE TABLE", () => {
+    const ast = parsePg(
+      "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL);",
+    );
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0].name).toBe("users");
+    expect(result.tables[0].fields).toHaveLength(2);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[1].notNull).toBe(true);
+  });
+
+  it("parses SERIAL as custom type", () => {
+    const ast = parsePg(
+      "CREATE TABLE users (id SERIAL PRIMARY KEY);",
+    );
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables[0].fields[0].type).toBe("SERIAL");
+    expect(result.tables[0].fields[0].primary).toBe(true);
+  });
+
+  it("parses CREATE TYPE AS ENUM", () => {
+    const ast = parsePg(`
+      CREATE TYPE status AS ENUM ('active', 'inactive', 'pending');
+      CREATE TABLE users (id INTEGER PRIMARY KEY, status status);
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.enums).toHaveLength(1);
+    expect(result.enums[0].name).toBe("status");
+    expect(result.enums[0].values).toEqual(["active", "inactive", "pending"]);
+
+    expect(result.tables[0].fields[1].type).toBe("status");
+  });
+
+  it("parses CREATE TYPE AS composite", () => {
+    const ast = parsePg(
+      "CREATE TYPE address AS (street TEXT, city TEXT, zip VARCHAR(10));",
+    );
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.types).toHaveLength(1);
+    expect(result.types[0].name).toBe("address");
+    expect(result.types[0].fields).toHaveLength(3);
+    expect(result.types[0].fields[0].name).toBe("street");
+    expect(result.types[0].fields[2].size).toBe("10");
+  });
+
+  it("parses COMMENT ON TABLE", () => {
+    const ast = parsePg(`
+      CREATE TABLE users (id INTEGER PRIMARY KEY);
+      COMMENT ON TABLE users IS 'User accounts';
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables[0].comment).toBe("User accounts");
+  });
+
+  it("parses COMMENT ON COLUMN", () => {
+    const ast = parsePg(`
+      CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+      COMMENT ON COLUMN users.name IS 'Full name';
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables[0].fields[1].comment).toBe("Full name");
+  });
+
+  it("parses inline REFERENCES", () => {
+    const ast = parsePg(`
+      CREATE TABLE departments (id INTEGER PRIMARY KEY);
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY,
+        dept_id INTEGER REFERENCES departments(id) ON DELETE CASCADE
+      );
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Cascade");
+  });
+
+  it("parses FOREIGN KEY constraints", () => {
+    const ast = parsePg(`
+      CREATE TABLE departments (id INTEGER PRIMARY KEY);
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY,
+        dept_id INTEGER,
+        CONSTRAINT fk_dept FOREIGN KEY (dept_id) REFERENCES departments(id) ON DELETE SET NULL ON UPDATE CASCADE
+      );
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Set null");
+    expect(result.relationships[0].updateConstraint).toBe("Cascade");
+  });
+
+  it("parses ALTER TABLE ADD FOREIGN KEY", () => {
+    const ast = parsePg(`
+      CREATE TABLE a (id INTEGER PRIMARY KEY);
+      CREATE TABLE b (id INTEGER PRIMARY KEY, a_id INTEGER);
+      ALTER TABLE b ADD CONSTRAINT fk_a FOREIGN KEY (a_id) REFERENCES a(id);
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.relationships).toHaveLength(1);
+  });
+
+  it("parses CREATE INDEX", () => {
+    const ast = parsePg(`
+      CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
+      CREATE UNIQUE INDEX idx_email ON users (email);
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables[0].indices).toHaveLength(1);
+    expect(result.tables[0].indices[0].unique).toBe(true);
+    expect(result.tables[0].indices[0].fields).toEqual(["email"]);
+  });
+
+  it("parses DEFAULT values", () => {
+    const ast = parsePg(`
+      CREATE TABLE users (
+        active BOOLEAN DEFAULT TRUE,
+        count INTEGER DEFAULT 0,
+        ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables[0].fields[0].default).toBe("TRUE");
+    expect(result.tables[0].fields[1].default).toBe("0");
+    expect(result.tables[0].fields[2].default).toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("parses CHECK constraints", () => {
+    const ast = parsePg(
+      "CREATE TABLE users (age INTEGER CHECK (age > 0));",
+    );
+    const result = fromPostgres(ast, DB.POSTGRES);
+
+    expect(result.tables[0].fields[0].check).toContain(">");
+  });
+
+  it("maps types to GENERIC affinity", () => {
+    const ast = parsePg(
+      "CREATE TABLE t (a INTEGER, b BOOLEAN);",
+    );
+    const result = fromPostgres(ast, DB.GENERIC);
+
+    expect(result.tables[0].fields[0].type).toBe("INT");
+  });
+});

--- a/src/utils/importSQL/__tests__/setup.js
+++ b/src/utils/importSQL/__tests__/setup.js
@@ -1,0 +1,6 @@
+import { init } from "@guanmingchiu/sqlparser-ts";
+import { beforeAll } from "vitest";
+
+beforeAll(async () => {
+  await init();
+});

--- a/src/utils/importSQL/__tests__/shared.test.js
+++ b/src/utils/importSQL/__tests__/shared.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSQLFromAST,
+  getTypeName,
+  getTypeSize,
+  getTableName,
+  getIndexColumnName,
+  mapReferentialAction,
+  extractDefaultValue,
+} from "../shared";
+import { DB } from "../../../data/constants";
+
+describe("getTypeName", () => {
+  it("handles string data types", () => {
+    expect(getTypeName("Date")).toBe("DATE");
+    expect(getTypeName("Text")).toBe("TEXT");
+    expect(getTypeName("Boolean")).toBe("BOOLEAN");
+    expect(getTypeName("Real")).toBe("REAL");
+  });
+
+  it("handles object data types with empty value (unit variants)", () => {
+    expect(getTypeName({ Int: {} })).toBe("INT");
+    expect(getTypeName({ BigInt: {} })).toBe("BIGINT");
+    expect(getTypeName({ SmallInt: {} })).toBe("SMALLINT");
+    expect(getTypeName({ Blob: {} })).toBe("BLOB");
+  });
+
+  it("handles parameterized data types", () => {
+    expect(getTypeName({ Varchar: { IntegerLength: { length: 255 } } })).toBe(
+      "VARCHAR",
+    );
+    expect(
+      getTypeName({ Decimal: { PrecisionAndScale: [10, 2] } }),
+    ).toBe("DECIMAL");
+  });
+});
+
+describe("getTypeSize", () => {
+  it("returns null for string types", () => {
+    expect(getTypeSize("Date")).toBeNull();
+  });
+
+  it("returns null for unit variant types", () => {
+    expect(getTypeSize({ Int: {} })).toBeNull();
+  });
+
+  it("extracts length from parameterized types", () => {
+    expect(getTypeSize({ Varchar: { IntegerLength: { length: 255 } } })).toEqual(
+      { length: 255 },
+    );
+  });
+
+  it("extracts precision and scale", () => {
+    expect(
+      getTypeSize({ Decimal: { PrecisionAndScale: [10, 2] } }),
+    ).toEqual({ length: 10, scale: 2 });
+  });
+});
+
+describe("getTableName", () => {
+  it("extracts name from simple ObjectName", () => {
+    const name = [{ Identifier: { value: "users" } }];
+    expect(getTableName(name)).toBe("users");
+  });
+
+  it("extracts name from schema-qualified ObjectName", () => {
+    const name = [
+      { Identifier: { value: "public" } },
+      { Identifier: { value: "users" } },
+    ];
+    expect(getTableName(name)).toBe("users");
+  });
+});
+
+describe("getIndexColumnName", () => {
+  it("extracts column name from index column", () => {
+    const col = {
+      column: { expr: { Identifier: { value: "email" } } },
+    };
+    expect(getIndexColumnName(col)).toBe("email");
+  });
+});
+
+describe("mapReferentialAction", () => {
+  it("maps known actions", () => {
+    expect(mapReferentialAction("Cascade")).toBe("Cascade");
+    expect(mapReferentialAction("SetNull")).toBe("Set null");
+    expect(mapReferentialAction("SetDefault")).toBe("Set default");
+    expect(mapReferentialAction("NoAction")).toBe("No action");
+    expect(mapReferentialAction("Restrict")).toBe("Restrict");
+  });
+
+  it("returns No action for undefined", () => {
+    expect(mapReferentialAction(undefined)).toBe("No action");
+  });
+});
+
+describe("extractDefaultValue", () => {
+  it("extracts string default", () => {
+    const expr = { Value: { value: { SingleQuotedString: "hello" } } };
+    expect(extractDefaultValue(expr)).toBe("hello");
+  });
+
+  it("extracts numeric default", () => {
+    const expr = { Value: { value: { Number: ["42", false] } } };
+    expect(extractDefaultValue(expr)).toBe("42");
+  });
+
+  it("extracts NULL default", () => {
+    const expr = { Value: { value: "Null" } };
+    expect(extractDefaultValue(expr)).toBe("NULL");
+  });
+
+  it("extracts function default", () => {
+    const expr = {
+      Function: {
+        name: [{ Identifier: { value: "CURRENT_TIMESTAMP" } }],
+        args: "None",
+      },
+    };
+    expect(extractDefaultValue(expr)).toBe("CURRENT_TIMESTAMP");
+  });
+
+  it("extracts boolean default", () => {
+    const expr = { Value: { value: { Boolean: true } } };
+    expect(extractDefaultValue(expr)).toBe("TRUE");
+  });
+});
+
+describe("buildSQLFromAST", () => {
+  it("builds binary expression", () => {
+    const expr = {
+      BinaryOp: {
+        left: { Identifier: { value: "age" } },
+        op: "Gt",
+        right: { Value: { value: { Number: ["0", false] } } },
+      },
+    };
+    expect(buildSQLFromAST(expr, DB.MYSQL)).toBe("`age` > 0");
+  });
+
+  it("builds nested expressions", () => {
+    const expr = {
+      Nested: {
+        BinaryOp: {
+          left: { Identifier: { value: "x" } },
+          op: "Gt",
+          right: { Value: { value: { Number: ["1", false] } } },
+        },
+      },
+    };
+    expect(buildSQLFromAST(expr, DB.MYSQL)).toBe("(`x` > 1)");
+  });
+
+  it("builds function expressions", () => {
+    const expr = {
+      Function: {
+        name: [{ Identifier: { value: "LENGTH" } }],
+        args: [
+          {
+            Unnamed: {
+              Expr: { Identifier: { value: "name" } },
+            },
+          },
+        ],
+      },
+    };
+    expect(buildSQLFromAST(expr, DB.MYSQL)).toBe("LENGTH(`name`)");
+  });
+
+  it("handles string values", () => {
+    const expr = {
+      Value: { value: { SingleQuotedString: "test" } },
+    };
+    expect(buildSQLFromAST(expr, DB.MYSQL)).toBe("'test'");
+  });
+
+  it("handles NULL", () => {
+    const expr = { Value: { value: "Null" } };
+    expect(buildSQLFromAST(expr, DB.MYSQL)).toBe("NULL");
+  });
+
+  it("handles IS NULL", () => {
+    const expr = { IsNull: { Identifier: { value: "col" } } };
+    expect(buildSQLFromAST(expr, DB.MYSQL)).toBe("`col` IS NULL");
+  });
+});

--- a/src/utils/importSQL/__tests__/sqlite.test.js
+++ b/src/utils/importSQL/__tests__/sqlite.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "@guanmingchiu/sqlparser-ts";
+import { fromSQLite } from "../sqlite";
+import { DB } from "../../../data/constants";
+
+function parseSQLite(sql) {
+  return parse(sql, "sqlite");
+}
+
+describe("fromSQLite", () => {
+  it("parses a basic CREATE TABLE", () => {
+    const ast = parseSQLite(
+      "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+    );
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0].name).toBe("users");
+    expect(result.tables[0].fields).toHaveLength(2);
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[1].notNull).toBe(true);
+  });
+
+  it("parses AUTOINCREMENT", () => {
+    const ast = parseSQLite(
+      "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT);",
+    );
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables[0].fields[0].primary).toBe(true);
+  });
+
+  it("parses inline REFERENCES", () => {
+    const ast = parseSQLite(`
+      CREATE TABLE categories (id INTEGER PRIMARY KEY, name TEXT);
+      CREATE TABLE products (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        category_id INTEGER REFERENCES categories(id) ON DELETE SET NULL
+      );
+    `);
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables).toHaveLength(2);
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Set null");
+  });
+
+  it("parses FOREIGN KEY constraint", () => {
+    const ast = parseSQLite(`
+      CREATE TABLE a (id INTEGER PRIMARY KEY);
+      CREATE TABLE b (
+        id INTEGER PRIMARY KEY,
+        a_id INTEGER,
+        FOREIGN KEY (a_id) REFERENCES a(id) ON DELETE CASCADE
+      );
+    `);
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].deleteConstraint).toBe("Cascade");
+  });
+
+  it("parses PRIMARY KEY constraint", () => {
+    const ast = parseSQLite(
+      "CREATE TABLE t (a INTEGER, b TEXT, PRIMARY KEY (a));",
+    );
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables[0].fields[0].primary).toBe(true);
+    expect(result.tables[0].fields[1].primary).toBe(false);
+  });
+
+  it("parses DEFAULT values", () => {
+    const ast = parseSQLite(`
+      CREATE TABLE t (
+        a TEXT DEFAULT 'hello',
+        b INTEGER DEFAULT 42,
+        c TEXT DEFAULT NULL
+      );
+    `);
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables[0].fields[0].default).toBe("hello");
+    expect(result.tables[0].fields[1].default).toBe("42");
+    expect(result.tables[0].fields[2].default).toBe("NULL");
+  });
+
+  it("parses CREATE INDEX", () => {
+    const ast = parseSQLite(`
+      CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
+      CREATE INDEX idx_email ON users (email);
+    `);
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables[0].indices).toHaveLength(1);
+    expect(result.tables[0].indices[0].name).toBe("idx_email");
+    expect(result.tables[0].indices[0].unique).toBe(false);
+  });
+
+  it("parses CHECK constraints", () => {
+    const ast = parseSQLite(
+      "CREATE TABLE users (age INTEGER CHECK (age > 0));",
+    );
+    const result = fromSQLite(ast, DB.SQLITE);
+
+    expect(result.tables[0].fields[0].check).toContain(">");
+  });
+
+  it("maps types with GENERIC affinity", () => {
+    const ast = parseSQLite(
+      "CREATE TABLE t (a INTEGER, b TINYINT, c NVARCHAR(50));",
+    );
+    const result = fromSQLite(ast, DB.GENERIC);
+
+    expect(result.tables[0].fields[0].type).toBe("INT");
+    expect(result.tables[0].fields[1].type).toBe("SMALLINT");
+  });
+});

--- a/src/utils/importSQL/mariadb.js
+++ b/src/utils/importSQL/mariadb.js
@@ -1,7 +1,15 @@
 import { nanoid } from "nanoid";
 import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import {
+  buildSQLFromAST,
+  extractDefaultValue,
+  getTableName,
+  getTypeName,
+  getTypeSize,
+  getIndexColumnName,
+  mapReferentialAction,
+} from "./shared";
 
 const affinity = {
   [DB.MARIADB]: new Proxy(
@@ -24,223 +32,182 @@ export function fromMariaDB(ast, diagramDb = DB.GENERIC) {
   const tables = [];
   const relationships = [];
 
-  const parseSingleStatement = (e) => {
-    if (e.type === "create") {
-      if (e.keyword === "table") {
-        const table = {};
-        table.name = e.table[0].table;
-        table.comment = "";
-        table.color = "#175e7a";
-        table.fields = [];
-        table.indices = [];
-        table.id = nanoid();
-        e.create_definitions.forEach((d) => {
-          if (d.resource === "column") {
-            const field = {};
-            field.id = nanoid();
-            field.name = d.column.column;
+  const parseSingleStatement = (stmt) => {
+    if (stmt.CreateTable) {
+      const ct = stmt.CreateTable;
+      const table = {};
+      table.name = getTableName(ct.name);
+      table.comment = "";
+      table.color = "#175e7a";
+      table.fields = [];
+      table.indices = [];
+      table.id = nanoid();
 
-            let type = d.definition.dataType;
-            if (!dbToTypes[diagramDb][type]) {
-              type = affinity[diagramDb][type];
-            }
-            field.type = type;
+      ct.columns.forEach((col) => {
+        const field = {};
+        field.id = nanoid();
+        field.name = col.name.value;
 
-            if (d.definition.expr && d.definition.expr.type === "expr_list") {
-              field.values = d.definition.expr.value.map((v) => v.value);
-            }
-            field.comment = d.comment ? d.comment.value.value : "";
-            field.unique = false;
-            if (d.unique) field.unique = true;
-            field.increment = false;
-            if (d.auto_increment) field.increment = true;
-            field.notNull = false;
-            if (d.nullable) field.notNull = true;
-            field.primary = false;
-            if (d.primary_key) field.primary = true;
-            field.default = "";
-            if (d.default_val) {
-              let defaultValue = "";
-              if (d.default_val.value.type === "function") {
-                defaultValue = d.default_val.value.name.name[0].value;
-                if (d.default_val.value.args) {
-                  defaultValue +=
-                    "(" +
-                    d.default_val.value.args.value
-                      .map((v) => {
-                        if (
-                          v.type === "single_quote_string" ||
-                          v.type === "double_quote_string"
-                        )
-                          return "'" + v.value + "'";
-                        return v.value;
-                      })
-                      .join(", ") +
-                    ")";
-                }
-              } else if (d.default_val.value.type === "null") {
-                defaultValue = "NULL";
-              } else {
-                defaultValue = d.default_val.value.value.toString();
-              }
-              field.default = defaultValue;
-            }
-            if (d.definition["length"]) {
-              if (d.definition.scale) {
-                field.size = d.definition["length"] + "," + d.definition.scale;
-              } else {
-                field.size = d.definition["length"];
-              }
-            }
-            field.check = "";
-            if (d.check) {
-              field.check = buildSQLFromAST(d.check.definition[0], DB.MARIADB);
-            }
-
-            table.fields.push(field);
-          } else if (d.resource === "constraint") {
-            if (d.constraint_type === "primary key") {
-              d.definition.forEach((c) => {
-                table.fields.forEach((f) => {
-                  if (f.name === c.column && !f.primary) {
-                    f.primary = true;
-                  }
-                });
-              });
-            } else if (d.constraint_type.toLowerCase() === "foreign key") {
-              const relationship = {};
-              const startTableId = table.id;
-              const startTableName = e.table[0].table;
-              const startFieldName = d.definition[0].column;
-              const endTableName = d.reference_definition.table[0].table;
-              const endFieldName = d.reference_definition.definition[0].column;
-
-              const endTable = tables.find((t) => t.name === endTableName);
-              if (!endTable) return;
-
-              const endField = endTable.fields.find(
-                (f) => f.name === endFieldName,
-              );
-              if (!endField) return;
-
-              const startField = table.fields.find(
-                (f) => f.name === startFieldName,
-              );
-              if (!startField) return;
-
-              relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
-              relationship.startTableId = startTableId;
-              relationship.endTableId = endTable.id;
-              relationship.endFieldId = endField.id;
-              relationship.startFieldId = startField.id;
-              relationship.id = nanoid()
-              let updateConstraint = "No action";
-              let deleteConstraint = "No action";
-              d.reference_definition.on_action.forEach((c) => {
-                if (c.type === "on update") {
-                  updateConstraint = c.value.value;
-                  updateConstraint =
-                    updateConstraint[0].toUpperCase() +
-                    updateConstraint.substring(1);
-                } else if (c.type === "on delete") {
-                  deleteConstraint = c.value.value;
-                  deleteConstraint =
-                    deleteConstraint[0].toUpperCase() +
-                    deleteConstraint.substring(1);
-                }
-              });
-
-              relationship.updateConstraint = updateConstraint;
-              relationship.deleteConstraint = deleteConstraint;
-
-              if (startField.unique) {
-                relationship.cardinality = Cardinality.ONE_TO_ONE;
-              } else {
-                relationship.cardinality = Cardinality.MANY_TO_ONE;
-              }
-
-              relationships.push(relationship);
-            }
-          }
-        });
-
-        e.table_options?.forEach((opt) => {
-          if (opt.keyword === "comment") {
-            table.comment = opt.value.replace(/^["']|["']$/g, "");
-          }
-        });
-
-        tables.push(table);
-      } else if (e.keyword === "index") {
-        const index = {
-          name: e.index,
-          unique: e.index_type === "unique",
-          fields: e.index_columns.map((f) => f.column),
-        };
-
-        const table = tables.find((t) => t.name === e.table.table);
-
-        if (table) {
-          table.indices.push(index);
-          table.indices.forEach((i, j) => {
-            i.id = j;
-          });
+        let type = getTypeName(col.data_type);
+        if (!dbToTypes[diagramDb][type]) {
+          type = affinity[diagramDb][type];
         }
-      }
-    } else if (e.type === "alter") {
-      e.expr.forEach((expr) => {
-        if (
-          expr.action === "add" &&
-          expr.create_definitions.constraint_type.toLowerCase() ===
-            "foreign key"
-        ) {
-          const relationship = {};
-          const startTableName = e.table[0].table;
-          const startFieldName = expr.create_definitions.definition[0].column;
-          const endTableName =
-            expr.create_definitions.reference_definition.table[0].table;
-          const endFieldName =
-            expr.create_definitions.reference_definition.definition[0].column;
-          let updateConstraint = "No action";
-          let deleteConstraint = "No action";
-          expr.create_definitions.reference_definition.on_action.forEach(
-            (c) => {
-              if (c.type === "on update") {
-                updateConstraint = c.value.value;
-                updateConstraint =
-                  updateConstraint[0].toUpperCase() +
-                  updateConstraint.substring(1);
-              } else if (c.type === "on delete") {
-                deleteConstraint = c.value.value;
-                deleteConstraint =
-                  deleteConstraint[0].toUpperCase() +
-                  deleteConstraint.substring(1);
-              }
-            },
-          );
+        field.type = type;
 
-          const startTable = tables.find((t) => t.name === startTableName);
-          if (!startTable) return;
+        if (col.data_type?.Enum) {
+          const [variants] = col.data_type.Enum;
+          field.values = variants.map((v) => v.Name || v.value || v);
+        }
+
+        field.comment = "";
+        field.unique = false;
+        field.increment = false;
+        field.notNull = false;
+        field.primary = false;
+        field.default = "";
+        field.check = "";
+
+        const size = getTypeSize(col.data_type);
+        if (size) {
+          field.size = size.scale
+            ? `${size.length},${size.scale}`
+            : `${size.length}`;
+        }
+
+        col.options.forEach((opt) => {
+          const o = opt.option;
+          if (o === "NotNull") field.notNull = true;
+          if (o === "Null") field.notNull = false;
+          if (o.PrimaryKey) field.primary = true;
+          if (o.Unique) field.unique = true;
+          if (o.DialectSpecific) {
+            const tokens = o.DialectSpecific;
+            if (
+              tokens.some(
+                (t) =>
+                  t.Word?.keyword === "AUTO_INCREMENT" ||
+                  t.Word?.value === "AUTO_INCREMENT",
+              )
+            ) {
+              field.increment = true;
+            }
+          }
+          if (o.Default) field.default = extractDefaultValue(o.Default);
+          if (o.Check)
+            field.check = buildSQLFromAST(o.Check.expr, DB.MARIADB);
+          if (o.Comment !== undefined && typeof o.Comment === "string")
+            field.comment = o.Comment;
+        });
+
+        table.fields.push(field);
+      });
+
+      ct.constraints.forEach((c) => {
+        if (c.PrimaryKey) {
+          c.PrimaryKey.columns.forEach((pk) => {
+            const colName = getIndexColumnName(pk);
+            table.fields.forEach((f) => {
+              if (f.name === colName && !f.primary) {
+                f.primary = true;
+              }
+            });
+          });
+        } else if (c.ForeignKey) {
+          const fk = c.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          const endTableName = getTableName(fk.foreign_table);
+          const endFieldName = fk.referred_columns[0]?.value;
 
           const endTable = tables.find((t) => t.name === endTableName);
           if (!endTable) return;
-
-          const endField = endTable.fields.find((f) => f.name === endFieldName);
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
+          );
           if (!endField) return;
+          const startField = table.fields.find(
+            (f) => f.name === startFieldName,
+          );
+          if (!startField) return;
 
+          const relationship = {};
+          relationship.name = `fk_${table.name}_${startFieldName}_${endTableName}`;
+          relationship.startTableId = table.id;
+          relationship.endTableId = endTable.id;
+          relationship.endFieldId = endField.id;
+          relationship.startFieldId = startField.id;
+          relationship.id = nanoid();
+          relationship.updateConstraint = mapReferentialAction(fk.on_update);
+          relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
+
+          if (startField.unique) {
+            relationship.cardinality = Cardinality.ONE_TO_ONE;
+          } else {
+            relationship.cardinality = Cardinality.MANY_TO_ONE;
+          }
+
+          relationships.push(relationship);
+        }
+      });
+
+      if (ct.table_options?.Plain) {
+        ct.table_options.Plain.forEach((opt) => {
+          if (opt.Comment) {
+            table.comment =
+              opt.Comment.WithEq || opt.Comment.WithoutEq || opt.Comment;
+          }
+        });
+      }
+
+      tables.push(table);
+    } else if (stmt.CreateIndex) {
+      const ci = stmt.CreateIndex;
+      const tableName = getTableName(ci.table_name);
+      const indexName = ci.name ? getTableName(ci.name) : "";
+      const index = {
+        name: indexName,
+        unique: ci.unique,
+        fields: ci.columns.map((c) => getIndexColumnName(c)),
+      };
+
+      const table = tables.find((t) => t.name === tableName);
+      if (table) {
+        table.indices.push(index);
+        table.indices.forEach((i, j) => {
+          i.id = j;
+        });
+      }
+    } else if (stmt.AlterTable) {
+      const at = stmt.AlterTable;
+      const startTableName = getTableName(at.name);
+
+      at.operations.forEach((op) => {
+        if (op.AddConstraint?.constraint?.ForeignKey) {
+          const fk = op.AddConstraint.constraint.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          const endTableName = getTableName(fk.foreign_table);
+          const endFieldName = fk.referred_columns[0]?.value;
+
+          const startTable = tables.find((t) => t.name === startTableName);
+          if (!startTable) return;
+          const endTable = tables.find((t) => t.name === endTableName);
+          if (!endTable) return;
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
+          );
+          if (!endField) return;
           const startField = startTable.fields.find(
             (f) => f.name === startFieldName,
           );
           if (!startField) return;
 
-          relationship.name =
-            "fk_" + startTableName + "_" + startFieldName + "_" + endTableName;
+          const relationship = {};
+          relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
           relationship.startTableId = startTable.id;
           relationship.startFieldId = startField.id;
           relationship.endTableId = endTable.id;
           relationship.endFieldId = endField.id;
-          relationship.updateConstraint = updateConstraint;
-          relationship.deleteConstraint = deleteConstraint;
+          relationship.updateConstraint = mapReferentialAction(fk.on_update);
+          relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
           relationship.id = nanoid();
 
           if (startField.unique) {
@@ -255,11 +222,7 @@ export function fromMariaDB(ast, diagramDb = DB.GENERIC) {
     }
   };
 
-  if (Array.isArray(ast)) {
-    ast.forEach((e) => parseSingleStatement(e));
-  } else {
-    parseSingleStatement(ast);
-  }
+  ast.forEach((stmt) => parseSingleStatement(stmt));
 
   return { tables, relationships };
 }

--- a/src/utils/importSQL/mysql.js
+++ b/src/utils/importSQL/mysql.js
@@ -1,7 +1,15 @@
 import { nanoid } from "nanoid";
 import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import {
+  buildSQLFromAST,
+  extractDefaultValue,
+  getTableName,
+  getTypeName,
+  getTypeSize,
+  getIndexColumnName,
+  mapReferentialAction,
+} from "./shared";
 
 const affinity = {
   [DB.MYSQL]: new Proxy(
@@ -24,222 +32,181 @@ export function fromMySQL(ast, diagramDb = DB.GENERIC) {
   const tables = [];
   const relationships = [];
 
-  const parseSingleStatement = (e) => {
-    if (e.type === "create") {
-      if (e.keyword === "table") {
-        const table = {};
-        table.name = e.table[0].table;
-        table.comment = "";
-        table.color = "#175e7a";
-        table.fields = [];
-        table.indices = [];
-        table.id = nanoid();
-        e.create_definitions.forEach((d) => {
-          if (d.resource === "column") {
-            const field = {};
-            field.id = nanoid();
-            field.name = d.column.column;
+  const parseSingleStatement = (stmt) => {
+    if (stmt.CreateTable) {
+      const ct = stmt.CreateTable;
+      const table = {};
+      table.name = getTableName(ct.name);
+      table.comment = "";
+      table.color = "#175e7a";
+      table.fields = [];
+      table.indices = [];
+      table.id = nanoid();
 
-            let type = d.definition.dataType;
-            if (!dbToTypes[diagramDb][type]) {
-              type = affinity[diagramDb][type];
-            }
-            field.type = type;
+      ct.columns.forEach((col) => {
+        const field = {};
+        field.id = nanoid();
+        field.name = col.name.value;
 
-            if (d.definition.expr && d.definition.expr.type === "expr_list") {
-              field.values = d.definition.expr.value.map((v) => v.value);
-            }
-            field.comment = d.comment ? d.comment.value.value : "";
-            field.unique = false;
-            if (d.unique) field.unique = true;
-            field.increment = false;
-            if (d.auto_increment) field.increment = true;
-            field.notNull = false;
-            if (d.nullable) field.notNull = true;
-            field.primary = false;
-            if (d.primary_key) field.primary = true;
-            field.default = "";
-            if (d.default_val) {
-              let defaultValue = "";
-              if (d.default_val.value.type === "function") {
-                defaultValue = d.default_val.value.name.name[0].value;
-                if (d.default_val.value.args) {
-                  defaultValue +=
-                    "(" +
-                    d.default_val.value.args.value
-                      .map((v) => {
-                        if (
-                          v.type === "single_quote_string" ||
-                          v.type === "double_quote_string"
-                        )
-                          return "'" + v.value + "'";
-                        return v.value;
-                      })
-                      .join(", ") +
-                    ")";
-                }
-              } else if (d.default_val.value.type === "null") {
-                defaultValue = "NULL";
-              } else {
-                defaultValue = d.default_val.value.value.toString();
-              }
-              field.default = defaultValue;
-            }
-            if (d.definition["length"]) {
-              if (d.definition.scale) {
-                field.size = d.definition["length"] + "," + d.definition.scale;
-              } else {
-                field.size = d.definition["length"];
-              }
-            }
-            field.check = "";
-            if (d.check) {
-              field.check = buildSQLFromAST(d.check.definition[0], DB.MYSQL);
-            }
-
-            table.fields.push(field);
-          } else if (d.resource === "constraint") {
-            if (d.constraint_type === "primary key") {
-              d.definition.forEach((c) => {
-                table.fields.forEach((f) => {
-                  if (f.name === c.column && !f.primary) {
-                    f.primary = true;
-                  }
-                });
-              });
-            } else if (d.constraint_type.toLowerCase() === "foreign key") {
-              const relationship = {};
-              const startTableName = e.table[0].table;
-              const startFieldName = d.definition[0].column;
-              const endTableName = d.reference_definition.table[0].table;
-              const endFieldName = d.reference_definition.definition[0].column;
-
-              const endTable = tables.find((t) => t.name === endTableName);
-              if (!endTable) return;
-
-              const endField = endTable.fields.find(
-                (f) => f.name === endFieldName,
-              );
-              if (!endField) return;
-
-              const startField = table.fields.find(
-                (f) => f.name === startFieldName,
-              );
-              if (!startField) return;
-
-              relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
-              relationship.startTableId = table.id;
-              relationship.endTableId = endTable.id;
-              relationship.endFieldId = endField.id;
-              relationship.startFieldId = startField.id;
-              relationship.id = nanoid();
-
-              let updateConstraint = "No action";
-              let deleteConstraint = "No action";
-              d.reference_definition.on_action.forEach((c) => {
-                if (c.type === "on update") {
-                  updateConstraint = c.value.value;
-                  updateConstraint =
-                    updateConstraint[0].toUpperCase() +
-                    updateConstraint.substring(1);
-                } else if (c.type === "on delete") {
-                  deleteConstraint = c.value.value;
-                  deleteConstraint =
-                    deleteConstraint[0].toUpperCase() +
-                    deleteConstraint.substring(1);
-                }
-              });
-
-              relationship.updateConstraint = updateConstraint;
-              relationship.deleteConstraint = deleteConstraint;
-
-              if (startField.unique) {
-                relationship.cardinality = Cardinality.ONE_TO_ONE;
-              } else {
-                relationship.cardinality = Cardinality.MANY_TO_ONE;
-              }
-
-              relationships.push(relationship);
-            }
-          }
-        });
-
-        e.table_options?.forEach((opt) => {
-          if (opt.keyword === "comment") {
-            table.comment = opt.value.replace(/^["']|["']$/g, "");
-          }
-        });
-
-        tables.push(table);
-      } else if (e.keyword === "index") {
-        const index = {
-          name: e.index,
-          unique: e.index_type === "unique",
-          fields: e.index_columns.map((f) => f.column),
-        };
-
-        const table = tables.find((t) => t.name === e.table.table);
-
-        if (table) {
-          table.indices.push(index);
-          table.indices.forEach((i, j) => {
-            i.id = j;
-          });
+        let type = getTypeName(col.data_type);
+        if (!dbToTypes[diagramDb][type]) {
+          type = affinity[diagramDb][type];
         }
-      }
-    } else if (e.type === "alter") {
-      e.expr.forEach((expr) => {
-        if (
-          expr.action === "add" &&
-          expr.create_definitions.constraint_type.toLowerCase() ===
-            "foreign key"
-        ) {
-          const relationship = {};
-          const startTableName = e.table[0].table;
-          const startFieldName = expr.create_definitions.definition[0].column;
-          const endTableName =
-            expr.create_definitions.reference_definition.table[0].table;
-          const endFieldName =
-            expr.create_definitions.reference_definition.definition[0].column;
-          let updateConstraint = "No action";
-          let deleteConstraint = "No action";
-          expr.create_definitions.reference_definition.on_action.forEach(
-            (c) => {
-              if (c.type === "on update") {
-                updateConstraint = c.value.value;
-                updateConstraint =
-                  updateConstraint[0].toUpperCase() +
-                  updateConstraint.substring(1);
-              } else if (c.type === "on delete") {
-                deleteConstraint = c.value.value;
-                deleteConstraint =
-                  deleteConstraint[0].toUpperCase() +
-                  deleteConstraint.substring(1);
-              }
-            },
-          );
+        field.type = type;
 
-          const startTable = tables.find((t) => t.name === startTableName);
-          if (!startTable) return;
+        if (col.data_type?.Enum) {
+          const [variants] = col.data_type.Enum;
+          field.values = variants.map((v) => v.Name || v.value || v);
+        }
+
+        field.comment = "";
+        field.unique = false;
+        field.increment = false;
+        field.notNull = false;
+        field.primary = false;
+        field.default = "";
+        field.check = "";
+
+        const size = getTypeSize(col.data_type);
+        if (size) {
+          field.size = size.scale
+            ? `${size.length},${size.scale}`
+            : `${size.length}`;
+        }
+
+        col.options.forEach((opt) => {
+          const o = opt.option;
+          if (o === "NotNull") field.notNull = true;
+          if (o === "Null") field.notNull = false;
+          if (o.PrimaryKey) field.primary = true;
+          if (o.Unique) field.unique = true;
+          if (o.DialectSpecific) {
+            const tokens = o.DialectSpecific;
+            if (
+              tokens.some(
+                (t) =>
+                  t.Word?.keyword === "AUTO_INCREMENT" ||
+                  t.Word?.value === "AUTO_INCREMENT",
+              )
+            ) {
+              field.increment = true;
+            }
+          }
+          if (o.Default) field.default = extractDefaultValue(o.Default);
+          if (o.Check) field.check = buildSQLFromAST(o.Check.expr, DB.MYSQL);
+          if (o.Comment !== undefined && typeof o.Comment === "string")
+            field.comment = o.Comment;
+        });
+
+        table.fields.push(field);
+      });
+
+      ct.constraints.forEach((c) => {
+        if (c.PrimaryKey) {
+          c.PrimaryKey.columns.forEach((pk) => {
+            const colName = getIndexColumnName(pk);
+            table.fields.forEach((f) => {
+              if (f.name === colName && !f.primary) {
+                f.primary = true;
+              }
+            });
+          });
+        } else if (c.ForeignKey) {
+          const fk = c.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          const endTableName = getTableName(fk.foreign_table);
+          const endFieldName = fk.referred_columns[0]?.value;
 
           const endTable = tables.find((t) => t.name === endTableName);
           if (!endTable) return;
-
-          const endField = endTable.fields.find((f) => f.name === endFieldName);
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
+          );
           if (!endField) return;
+          const startField = table.fields.find(
+            (f) => f.name === startFieldName,
+          );
+          if (!startField) return;
 
+          const relationship = {};
+          relationship.name = `fk_${table.name}_${startFieldName}_${endTableName}`;
+          relationship.startTableId = table.id;
+          relationship.endTableId = endTable.id;
+          relationship.endFieldId = endField.id;
+          relationship.startFieldId = startField.id;
+          relationship.id = nanoid();
+          relationship.updateConstraint = mapReferentialAction(fk.on_update);
+          relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
+
+          if (startField.unique) {
+            relationship.cardinality = Cardinality.ONE_TO_ONE;
+          } else {
+            relationship.cardinality = Cardinality.MANY_TO_ONE;
+          }
+
+          relationships.push(relationship);
+        }
+      });
+
+      if (ct.table_options?.Plain) {
+        ct.table_options.Plain.forEach((opt) => {
+          if (opt.Comment) {
+            table.comment =
+              opt.Comment.WithEq || opt.Comment.WithoutEq || opt.Comment;
+          }
+        });
+      }
+
+      tables.push(table);
+    } else if (stmt.CreateIndex) {
+      const ci = stmt.CreateIndex;
+      const tableName = getTableName(ci.table_name);
+      const indexName = ci.name ? getTableName(ci.name) : "";
+      const index = {
+        name: indexName,
+        unique: ci.unique,
+        fields: ci.columns.map((c) => getIndexColumnName(c)),
+      };
+
+      const table = tables.find((t) => t.name === tableName);
+      if (table) {
+        table.indices.push(index);
+        table.indices.forEach((i, j) => {
+          i.id = j;
+        });
+      }
+    } else if (stmt.AlterTable) {
+      const at = stmt.AlterTable;
+      const startTableName = getTableName(at.name);
+
+      at.operations.forEach((op) => {
+        if (op.AddConstraint?.constraint?.ForeignKey) {
+          const fk = op.AddConstraint.constraint.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          const endTableName = getTableName(fk.foreign_table);
+          const endFieldName = fk.referred_columns[0]?.value;
+
+          const startTable = tables.find((t) => t.name === startTableName);
+          if (!startTable) return;
+          const endTable = tables.find((t) => t.name === endTableName);
+          if (!endTable) return;
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
+          );
+          if (!endField) return;
           const startField = startTable.fields.find(
             (f) => f.name === startFieldName,
           );
           if (!startField) return;
 
+          const relationship = {};
           relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
           relationship.startTableId = startTable.id;
           relationship.startFieldId = startField.id;
           relationship.endTableId = endTable.id;
           relationship.endFieldId = endField.id;
-          relationship.updateConstraint = updateConstraint;
-          relationship.deleteConstraint = deleteConstraint;
+          relationship.updateConstraint = mapReferentialAction(fk.on_update);
+          relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
           relationship.id = nanoid();
 
           if (startField.unique) {
@@ -254,11 +221,7 @@ export function fromMySQL(ast, diagramDb = DB.GENERIC) {
     }
   };
 
-  if (Array.isArray(ast)) {
-    ast.forEach((e) => parseSingleStatement(e));
-  } else {
-    parseSingleStatement(ast);
-  }
+  ast.forEach((stmt) => parseSingleStatement(stmt));
 
   return { tables, relationships };
 }

--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { Cardinality, Constraint, DB } from "../../data/constants";
+import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
 import {
   buildSQLFromAST,

--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -1,7 +1,15 @@
 import { nanoid } from "nanoid";
 import { Cardinality, Constraint, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import {
+  buildSQLFromAST,
+  extractDefaultValue,
+  getTableName,
+  getTypeName,
+  getTypeSize,
+  getIndexColumnName,
+  mapReferentialAction,
+} from "./shared";
 
 const affinity = {
   [DB.POSTGRES]: new Proxy(
@@ -25,366 +33,309 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
   const types = [];
   const enums = [];
 
-  const parseSingleStatement = (e) => {
-    if (e.type === "create") {
-      if (e.keyword === "table") {
-        const table = {};
-        table.name = e.table[0].table;
-        table.comment = "";
-        table.color = "#175e7a";
-        table.fields = [];
-        table.indices = [];
-        table.id = nanoid();
-        e.create_definitions.forEach((d) => {
-          const field = {};
-          if (d.resource === "column") {
-            field.id = nanoid();
-            field.name = d.column.column.expr.value;
+  const parseSingleStatement = (stmt) => {
+    if (stmt.CreateTable) {
+      const ct = stmt.CreateTable;
+      const table = {};
+      table.name = getTableName(ct.name);
+      table.comment = "";
+      table.color = "#175e7a";
+      table.fields = [];
+      table.indices = [];
+      table.id = nanoid();
 
-            let type = types.find((t) =>
-              new RegExp(`^(${t.name}|"${t.name}")$`).test(
-                d.definition.dataType,
-              ),
-            )?.name;
-            type ??= enums.find((t) =>
-              new RegExp(`^(${t.name}|"${t.name}")$`).test(
-                d.definition.dataType,
-              ),
-            )?.name;
+      ct.columns.forEach((col) => {
+        const field = {};
+        field.id = nanoid();
+        field.name = col.name.value;
 
-            type ??=
-              dbToTypes[diagramDb][d.definition.dataType.toUpperCase()].type;
-            type ??= affinity[diagramDb][d.definition.dataType.toUpperCase()];
+        let type = getTypeName(col.data_type);
 
-            field.type = type;
+        const matchedType = types.find((t) =>
+          new RegExp(`^(${t.name}|"${t.name}")$`).test(type),
+        )?.name;
+        const matchedEnum = enums.find((t) =>
+          new RegExp(`^(${t.name}|"${t.name}")$`).test(type),
+        )?.name;
 
-            if (d.definition.expr && d.definition.expr.type === "expr_list") {
-              field.values = d.definition.expr.value.map((v) => v.value);
+        if (matchedType) {
+          type = matchedType;
+        } else if (matchedEnum) {
+          type = matchedEnum;
+        } else {
+          // Handle Custom types (user-defined or dialect-specific like SERIAL)
+          if (col.data_type?.Custom) {
+            const customName = getTableName(col.data_type.Custom[0]);
+            const knownType = types.find((t) => t.name === customName)?.name;
+            const knownEnum = enums.find((t) => t.name === customName)?.name;
+            if (knownType) {
+              type = knownType;
+            } else if (knownEnum) {
+              type = knownEnum;
+            } else {
+              type = customName.toUpperCase();
             }
-            field.comment = d.comment ? d.comment.value.value : "";
-            field.unique = false;
-            if (d.unique) field.unique = true;
-            field.increment = false;
-            if (d.auto_increment) field.increment = true;
-            field.notNull = false;
-            if (d.nullable) field.notNull = true;
-            field.primary = false;
-            if (d.primary_key) field.primary = true;
-            field.default = "";
-            if (d.default_val) {
-              let defaultValue = "";
-              if (d.default_val.value.type === "function") {
-                defaultValue = d.default_val.value.name.name[0].value;
-                if (d.default_val.value.args) {
-                  defaultValue +=
-                    "(" +
-                    d.default_val.value.args.value
-                      .map((v) => {
-                        if (
-                          v.type === "single_quote_string" ||
-                          v.type === "double_quote_string"
-                        )
-                          return "'" + v.value + "'";
-                        return v.value;
-                      })
-                      .join(", ") +
-                    ")";
-                }
-              } else if (d.default_val.value.type === "null") {
-                defaultValue = "NULL";
-              } else if (d.default_val.value.type === "cast") {
-                defaultValue = d.default_val.value.expr.value;
-              } else if (d.default_val.value.type === "array") {
-                defaultValue = `ARRAY[${d.default_val.value.expr_list.value
-                  .map((v) => v.value ?? v.expr.value)
-                  .join(", ")}]`;
-              } else {
-                defaultValue = d.default_val.value.value.toString();
-              }
-              field.default = defaultValue;
-            }
-            if (d.definition["length"]) {
-              if (d.definition.scale) {
-                field.size = d.definition["length"] + "," + d.definition.scale;
-              } else {
-                field.size = d.definition["length"];
-              }
-            }
-            field.check = "";
-            if (d.check) {
-              field.check = buildSQLFromAST(d.check.definition[0], DB.POSTGRES);
-            }
-
-            table.fields.push(field);
-          } else if (d.resource === "constraint") {
-            if (d.constraint_type === "primary key") {
-              d.definition.forEach((c) => {
-                table.fields.forEach((f) => {
-                  if (f.name === c.column.expr.value && !f.primary) {
-                    f.primary = true;
-                  }
-                });
-              });
-            } else if (d.constraint_type.toLowerCase() === "foreign key") {
-              const relationship = {};
-              const startTableId = table.id;
-              const startTableName = e.table[0].table;
-              const startFieldName = d.definition[0].column.expr.value;
-              const endTableName = d.reference_definition.table[0].table;
-              const endFieldName =
-                d.reference_definition.definition[0].column.expr.value;
-
-              const endTable = tables.find((t) => t.name === endTableName);
-              if (!endTable) return;
-
-              const endField = endTable.fields.find(
-                (f) => f.name === endFieldName,
-              );
-              if (!endField) return;
-
-              const startField = table.fields.find(
-                (f) => f.name === startFieldName,
-              );
-              if (!startField) return;
-
-              relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
-              relationship.startTableId = startTableId;
-              relationship.endTableId = endTable.id;
-              relationship.endFieldId = endField.id;
-              relationship.startFieldId = startField.id;
-              relationship.id = nanoid();
-
-              let updateConstraint = Constraint.NONE;
-              let deleteConstraint = Constraint.NONE;
-              d.reference_definition.on_action.forEach((c) => {
-                if (c.type === "on update") {
-                  updateConstraint = c.value.value;
-                  updateConstraint =
-                    updateConstraint[0].toUpperCase() +
-                    updateConstraint.substring(1);
-                } else if (c.type === "on delete") {
-                  deleteConstraint = c.value.value;
-                  deleteConstraint =
-                    deleteConstraint[0].toUpperCase() +
-                    deleteConstraint.substring(1);
-                }
-              });
-
-              relationship.updateConstraint = updateConstraint;
-              relationship.deleteConstraint = deleteConstraint;
-              if (startField.unique) {
-                relationship.cardinality = Cardinality.ONE_TO_ONE;
-              } else {
-                relationship.cardinality = Cardinality.MANY_TO_ONE;
-              }
-              relationships.push(relationship);
+          } else {
+            type = type.toUpperCase();
+            if (dbToTypes[diagramDb][type]) {
+              type = dbToTypes[diagramDb][type].type || type;
+            } else {
+              type = affinity[diagramDb][type];
             }
           }
+        }
 
-          if (d.reference_definition) {
-            const relationship = {};
-            const startTableName = table.name;
-            const startFieldName = field.name;
-            const endTableName = d.reference_definition.table[0].table;
-            const endFieldName =
-              d.reference_definition.definition[0].column.expr.value;
-            let updateConstraint = Constraint.NONE;
-            let deleteConstraint = Constraint.NONE;
-            d.reference_definition.on_action.forEach((c) => {
-              if (c.type === "on update") {
-                updateConstraint = c.value.value;
-                updateConstraint =
-                  updateConstraint[0].toUpperCase() +
-                  updateConstraint.substring(1);
-              } else if (c.type === "on delete") {
-                deleteConstraint = c.value.value;
-                deleteConstraint =
-                  deleteConstraint[0].toUpperCase() +
-                  deleteConstraint.substring(1);
+        field.type = type;
+
+        if (col.data_type?.Enum) {
+          const [variants] = col.data_type.Enum;
+          field.values = variants.map((v) => v.Name || v.value || v);
+        }
+
+        field.comment = "";
+        field.unique = false;
+        field.increment = false;
+        field.notNull = false;
+        field.primary = false;
+        field.default = "";
+        field.check = "";
+
+        const size = getTypeSize(col.data_type);
+        if (size) {
+          field.size = size.scale
+            ? `${size.length},${size.scale}`
+            : `${size.length}`;
+        }
+
+        let inlineFk = null;
+
+        col.options.forEach((opt) => {
+          const o = opt.option;
+          if (o === "NotNull") field.notNull = true;
+          if (o === "Null") field.notNull = false;
+          if (o.PrimaryKey) field.primary = true;
+          if (o.Unique) field.unique = true;
+          if (o === "AutoIncrement" || o.Identity) field.increment = true;
+          if (o.Default) field.default = extractDefaultValue(o.Default);
+          if (o.Check)
+            field.check = buildSQLFromAST(o.Check.expr, DB.POSTGRES);
+          if (o.Comment !== undefined && typeof o.Comment === "string")
+            field.comment = o.Comment;
+          if (o.ForeignKey) {
+            inlineFk = o.ForeignKey;
+          }
+        });
+
+        table.fields.push(field);
+
+        if (inlineFk) {
+          const endTableName = getTableName(inlineFk.foreign_table);
+          const endFieldName = inlineFk.referred_columns[0]?.value;
+
+          const endTable = tables.find((t) => t.name === endTableName);
+          if (!endTable) return;
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
+          );
+          if (!endField) return;
+
+          const relationship = {};
+          relationship.name = `fk_${table.name}_${field.name}_${endTableName}`;
+          relationship.startTableId = table.id;
+          relationship.startFieldId = field.id;
+          relationship.endTableId = endTable.id;
+          relationship.endFieldId = endField.id;
+          relationship.updateConstraint = mapReferentialAction(
+            inlineFk.on_update,
+          );
+          relationship.deleteConstraint = mapReferentialAction(
+            inlineFk.on_delete,
+          );
+          relationship.id = nanoid();
+
+          if (field.unique) {
+            relationship.cardinality = Cardinality.ONE_TO_ONE;
+          } else {
+            relationship.cardinality = Cardinality.MANY_TO_ONE;
+          }
+
+          relationships.push(relationship);
+        }
+      });
+
+      ct.constraints.forEach((c) => {
+        if (c.PrimaryKey) {
+          c.PrimaryKey.columns.forEach((pk) => {
+            const colName = getIndexColumnName(pk);
+            table.fields.forEach((f) => {
+              if (f.name === colName && !f.primary) {
+                f.primary = true;
               }
             });
-
-            const startTableId = tables.length;
-
-            const endTable = tables.find((t) => t.name === endTableName);
-            if (!endTable) return;
-
-            const endField = endTable.fields.findIndex(
-              (f) => f.name === endFieldName,
-            );
-            if (!endField) return;
-
-            const startField = table.fields.find(
-              (f) => f.name === startFieldName,
-            );
-            if (!startField) return;
-
-            relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
-            relationship.startTableId = startTableId;
-            relationship.startFieldId = startField.id;
-            relationship.endTableId = endTable.id;
-            relationship.endFieldId = endField.id;
-            relationship.updateConstraint = updateConstraint;
-            relationship.deleteConstraint = deleteConstraint;
-            relationship.id = nanoid();
-
-            if (startField.unique) {
-              relationship.cardinality = Cardinality.ONE_TO_ONE;
-            } else {
-              relationship.cardinality = Cardinality.MANY_TO_ONE;
-            }
-
-            relationships.push(relationship);
-          }
-        });
-        tables.push(table);
-      } else if (e.keyword === "index") {
-        const index = {
-          name: e.index,
-          unique: e.index_type === "unique",
-          fields: e.index_columns.map((f) => f.column.expr.value),
-        };
-
-        const table = tables.find((t) => t.name === e.table.table);
-
-        if (table) {
-          table.indices.push(index);
-          table.indices.forEach((i, j) => {
-            i.id = j;
           });
-        }
-      } else if (e.keyword === "type") {
-        if (e.resource === "enum") {
-          const newEnum = {
-            name: e.name.name,
-            values: e.create_definitions.value.map((x) => x.value),
-          };
-          enums.push(newEnum);
-        } else if (Array.isArray(e.create_definitions)) {
-          const type = {
-            name: e.name.name,
-            fields: [],
-          };
-          e.create_definitions.forEach((d) => {
-            const field = {};
-            if (d.resource === "column") {
-              field.name = d.column.column.expr.value;
+        } else if (c.ForeignKey) {
+          const fk = c.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          const endTableName = getTableName(fk.foreign_table);
+          const endFieldName = fk.referred_columns[0]?.value;
 
-              let type = d.definition.dataType;
-              if (!dbToTypes[diagramDb][type]) {
-                type = affinity[diagramDb][type];
-              }
-              field.type = type;
-            }
-            if (d.definition["length"]) {
-              if (d.definition.scale) {
-                field.size = d.definition["length"] + "," + d.definition.scale;
-              } else {
-                field.size = d.definition["length"];
-              }
-            }
-
-            type.fields.push(field);
-          });
-          types.push(type);
-        }
-      }
-    } else if (e.type === "alter") {
-      if (Array.isArray(e.expr)) {
-        e.expr.forEach((expr) => {
-          if (
-            expr.action === "add" &&
-            expr.create_definitions.constraint_type.toLowerCase() ===
-              "foreign key"
-          ) {
-            const relationship = {};
-            const startTableName = e.table[0].table;
-            const startFieldName =
-              expr.create_definitions.definition[0].column.expr.value;
-            const endTableName =
-              expr.create_definitions.reference_definition.table[0].table;
-            const endFieldName =
-              expr.create_definitions.reference_definition.definition[0].column
-                .expr.value;
-            let updateConstraint = Constraint.NONE;
-            let deleteConstraint = Constraint.NONE;
-            expr.create_definitions.reference_definition.on_action.forEach(
-              (c) => {
-                if (c.type === "on update") {
-                  updateConstraint = c.value.value;
-                  updateConstraint =
-                    updateConstraint[0].toUpperCase() +
-                    updateConstraint.substring(1);
-                } else if (c.type === "on delete") {
-                  deleteConstraint = c.value.value;
-                  deleteConstraint =
-                    deleteConstraint[0].toUpperCase() +
-                    deleteConstraint.substring(1);
-                }
-              },
-            );
-
-            const startTable = tables.find((t) => t.name === startTableName);
-            if (!startTable) return;
-
-            const endTable = tables.find((t) => t.name === endTableName);
-            if (!endTable) return;
-
-            const endField = endTable.fields.find(
-              (f) => f.name === endFieldName,
-            );
-            if (!endField) return;
-
-            const startField = startTable.fields.find(
-              (f) => f.name === startFieldName,
-            );
-            if (!startField) return;
-
-            relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
-            relationship.startTableId = startTable.id;
-            relationship.startFieldId = startField.id;
-            relationship.endTableId = endTable.id;
-            relationship.endFieldId = endField.id;
-            relationship.updateConstraint = updateConstraint;
-            relationship.deleteConstraint = deleteConstraint;
-            relationship.cardinality = Cardinality.ONE_TO_ONE;
-            relationship.id = nanoid();
-
-            if (startField.unique) {
-              relationship.cardinality = Cardinality.ONE_TO_ONE;
-            } else {
-              relationship.cardinality = Cardinality.MANY_TO_ONE;
-            }
-
-            relationships.push(relationship);
-          }
-        });
-      }
-    } else if (e.type === "comment") {
-      if (e.target.type === "table") {
-        const table = tables.find((t) => t.name === e.target?.name?.table);
-        if (table) {
-          table.comment = e.expr.expr.value;
-        }
-      } else if (e.target.type === "column") {
-        const table = tables.find((t) => t.name === e.target?.name?.table);
-        if (table) {
-          const field = table.fields.find(
-            (f) => f.name === e.target?.name?.column?.expr?.value,
+          const endTable = tables.find((t) => t.name === endTableName);
+          if (!endTable) return;
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
           );
+          if (!endField) return;
+          const startField = table.fields.find(
+            (f) => f.name === startFieldName,
+          );
+          if (!startField) return;
+
+          const relationship = {};
+          relationship.name = `fk_${table.name}_${startFieldName}_${endTableName}`;
+          relationship.startTableId = table.id;
+          relationship.endTableId = endTable.id;
+          relationship.endFieldId = endField.id;
+          relationship.startFieldId = startField.id;
+          relationship.id = nanoid();
+          relationship.updateConstraint = mapReferentialAction(fk.on_update);
+          relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
+
+          if (startField.unique) {
+            relationship.cardinality = Cardinality.ONE_TO_ONE;
+          } else {
+            relationship.cardinality = Cardinality.MANY_TO_ONE;
+          }
+
+          relationships.push(relationship);
+        }
+      });
+
+      tables.push(table);
+    } else if (stmt.CreateIndex) {
+      const ci = stmt.CreateIndex;
+      const tableName = getTableName(ci.table_name);
+      const indexName = ci.name ? getTableName(ci.name) : "";
+      const index = {
+        name: indexName,
+        unique: ci.unique,
+        fields: ci.columns.map((c) => getIndexColumnName(c)),
+      };
+
+      const table = tables.find((t) => t.name === tableName);
+      if (table) {
+        table.indices.push(index);
+        table.indices.forEach((i, j) => {
+          i.id = j;
+        });
+      }
+    } else if (stmt.CreateType) {
+      const ct = stmt.CreateType;
+      const name = getTableName(ct.name);
+
+      if (ct.representation?.Enum) {
+        const newEnum = {
+          name,
+          values: ct.representation.Enum.labels.map(
+            (l) => l.value || l.Name || l,
+          ),
+        };
+        enums.push(newEnum);
+      } else if (ct.representation?.Composite) {
+        const type = {
+          name,
+          fields: [],
+        };
+        ct.representation.Composite.attributes.forEach((attr) => {
+          const field = {};
+          field.name = attr.name.value;
+          let typeName = getTypeName(attr.data_type);
+          if (!dbToTypes[diagramDb][typeName]) {
+            typeName = affinity[diagramDb][typeName];
+          }
+          field.type = typeName;
+
+          const size = getTypeSize(attr.data_type);
+          if (size) {
+            field.size = size.scale
+              ? `${size.length},${size.scale}`
+              : `${size.length}`;
+          }
+
+          type.fields.push(field);
+        });
+        types.push(type);
+      }
+    } else if (stmt.AlterTable) {
+      const at = stmt.AlterTable;
+      const startTableName = getTableName(at.name);
+
+      at.operations.forEach((op) => {
+        if (op.AddConstraint?.constraint?.ForeignKey) {
+          const fk = op.AddConstraint.constraint.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          const endTableName = getTableName(fk.foreign_table);
+          const endFieldName = fk.referred_columns[0]?.value;
+
+          const startTable = tables.find((t) => t.name === startTableName);
+          if (!startTable) return;
+          const endTable = tables.find((t) => t.name === endTableName);
+          if (!endTable) return;
+          const endField = endTable.fields.find(
+            (f) => f.name === endFieldName,
+          );
+          if (!endField) return;
+          const startField = startTable.fields.find(
+            (f) => f.name === startFieldName,
+          );
+          if (!startField) return;
+
+          const relationship = {};
+          relationship.name = `fk_${startTableName}_${startFieldName}_${endTableName}`;
+          relationship.startTableId = startTable.id;
+          relationship.startFieldId = startField.id;
+          relationship.endTableId = endTable.id;
+          relationship.endFieldId = endField.id;
+          relationship.updateConstraint = mapReferentialAction(fk.on_update);
+          relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
+          relationship.cardinality = Cardinality.ONE_TO_ONE;
+          relationship.id = nanoid();
+
+          if (startField.unique) {
+            relationship.cardinality = Cardinality.ONE_TO_ONE;
+          } else {
+            relationship.cardinality = Cardinality.MANY_TO_ONE;
+          }
+
+          relationships.push(relationship);
+        }
+      });
+    } else if (stmt.Comment) {
+      const c = stmt.Comment;
+      if (c.object_type === "Table") {
+        const tableName = getTableName(c.object_name);
+        const table = tables.find((t) => t.name === tableName);
+        if (table) {
+          table.comment = c.comment || "";
+        }
+      } else if (c.object_type === "Column") {
+        const tableName =
+          c.object_name.length >= 2
+            ? c.object_name[c.object_name.length - 2]?.Identifier?.value
+            : "";
+        const colName =
+          c.object_name[c.object_name.length - 1]?.Identifier?.value;
+        const table = tables.find((t) => t.name === tableName);
+        if (table) {
+          const field = table.fields.find((f) => f.name === colName);
           if (field) {
-            field.comment = e.expr.expr.value;
+            field.comment = c.comment || "";
           }
         }
       }
     }
   };
 
-  if (Array.isArray(ast)) {
-    ast.forEach((e) => parseSingleStatement(e));
-  } else {
-    parseSingleStatement(ast);
-  }
+  ast.forEach((stmt) => parseSingleStatement(stmt));
 
   return { tables, relationships, types, enums };
 }

--- a/src/utils/importSQL/shared.js
+++ b/src/utils/importSQL/shared.js
@@ -15,38 +15,222 @@ function quoteColumn(str, db) {
   }
 }
 
-export function buildSQLFromAST(ast, db = DB.MYSQL) {
-  if (ast.type === "binary_expr") {
-    const leftSQL = buildSQLFromAST(ast.left, db);
-    const rightSQL = buildSQLFromAST(ast.right, db);
-    return `${leftSQL} ${ast.operator} ${rightSQL}`;
+const opMap = {
+  Plus: "+",
+  Minus: "-",
+  Multiply: "*",
+  Divide: "/",
+  Modulo: "%",
+  Gt: ">",
+  Lt: "<",
+  GtEq: ">=",
+  LtEq: "<=",
+  Eq: "=",
+  NotEq: "!=",
+  And: "AND",
+  Or: "OR",
+};
+
+export function buildSQLFromAST(expr, db = DB.MYSQL) {
+  if (!expr) return "";
+
+  if (expr.BinaryOp) {
+    const left = buildSQLFromAST(expr.BinaryOp.left, db);
+    const right = buildSQLFromAST(expr.BinaryOp.right, db);
+    const op = opMap[expr.BinaryOp.op] || expr.BinaryOp.op;
+    return `${left} ${op} ${right}`;
   }
 
-  if (ast.type === "function") {
-    let expr = "";
-    expr = ast.name;
-    if (ast.args) {
-      expr +=
-        "(" +
-        ast.args.value
-          .map((v) => {
-            if (v.type === "column_ref") return "`" + v.column + "`";
-            if (
-              v.type === "single_quote_string" ||
-              v.type === "double_quote_string"
-            )
-              return "'" + v.value + "'";
-            return v.value;
-          })
-          .join(", ") +
-        ")";
-    }
-    return expr;
-  } else if (ast.type === "column_ref") {
-    return quoteColumn(ast.column, db);
-  } else if (ast.type === "expr_list") {
-    return ast.value.map((v) => v.value).join(" AND ");
-  } else {
-    return typeof ast.value === "string" ? "'" + ast.value + "'" : ast.value;
+  if (expr.UnaryOp) {
+    const operand = buildSQLFromAST(expr.UnaryOp.expr, db);
+    if (expr.UnaryOp.op === "Not") return `NOT ${operand}`;
+    if (expr.UnaryOp.op === "Minus") return `-${operand}`;
+    if (expr.UnaryOp.op === "Plus") return `+${operand}`;
+    return operand;
   }
+
+  if (expr.Nested) {
+    return `(${buildSQLFromAST(expr.Nested, db)})`;
+  }
+
+  if (expr.Identifier) {
+    return quoteColumn(expr.Identifier.value, db);
+  }
+
+  if (expr.CompoundIdentifier) {
+    return expr.CompoundIdentifier.map((i) => quoteColumn(i.value, db)).join(
+      ".",
+    );
+  }
+
+  if (expr.Function) {
+    const name = expr.Function.name
+      .map((n) => n.Identifier?.value || n.value || "")
+      .join(".");
+    if (expr.Function.args === "None" || !expr.Function.args) {
+      return name;
+    }
+    const args = Array.isArray(expr.Function.args)
+      ? expr.Function.args
+      : expr.Function.args.Unnamed
+        ? [expr.Function.args]
+        : [];
+    const argStrs = args
+      .map((a) => {
+        const argExpr = a.Unnamed?.Expr || a.Unnamed || a;
+        return buildSQLFromAST(argExpr, db);
+      })
+      .filter(Boolean);
+    return argStrs.length > 0 ? `${name}(${argStrs.join(", ")})` : name;
+  }
+
+  if (expr.Value) {
+    const val = expr.Value.value ?? expr.Value;
+    if (val === "Null") return "NULL";
+    if (val.SingleQuotedString !== undefined) return `'${val.SingleQuotedString}'`;
+    if (val.DoubleQuotedString !== undefined) return `'${val.DoubleQuotedString}'`;
+    if (val.Number) return val.Number[0];
+    if (val.Boolean !== undefined) return val.Boolean.toString().toUpperCase();
+    if (typeof val === "string") return val;
+    if (typeof val === "number") return val.toString();
+    return JSON.stringify(val);
+  }
+
+  if (expr.IsNull) return `${buildSQLFromAST(expr.IsNull, db)} IS NULL`;
+  if (expr.IsNotNull)
+    return `${buildSQLFromAST(expr.IsNotNull, db)} IS NOT NULL`;
+
+  if (expr.InList) {
+    const e = buildSQLFromAST(expr.InList.expr, db);
+    const list = expr.InList.list.map((v) => buildSQLFromAST(v, db)).join(", ");
+    return `${e}${expr.InList.negated ? " NOT" : ""} IN (${list})`;
+  }
+
+  if (expr.Between) {
+    const e = buildSQLFromAST(expr.Between.expr, db);
+    const low = buildSQLFromAST(expr.Between.low, db);
+    const high = buildSQLFromAST(expr.Between.high, db);
+    return `${e}${expr.Between.negated ? " NOT" : ""} BETWEEN ${low} AND ${high}`;
+  }
+
+  if (expr.Cast) {
+    return `CAST(${buildSQLFromAST(expr.Cast.expr, db)} AS ${getTypeName(expr.Cast.dataType)})`;
+  }
+
+  if (expr.Array) {
+    const elems = expr.Array.elem.map((e) => buildSQLFromAST(e, db)).join(", ");
+    return `ARRAY[${elems}]`;
+  }
+
+  if (typeof expr === "string") return expr;
+
+  return "";
+}
+
+export function getTypeName(dataType) {
+  if (typeof dataType === "string") return dataType.toUpperCase();
+  const key = Object.keys(dataType)[0];
+  return key ? key.toUpperCase() : "TEXT";
+}
+
+export function getTypeSize(dataType) {
+  if (typeof dataType === "string") return null;
+  const key = Object.keys(dataType)[0];
+  const val = dataType[key];
+  if (!val || typeof val !== "object") return null;
+  if (val.IntegerLength) {
+    return { length: val.IntegerLength.length };
+  }
+  if (val.PrecisionAndScale) {
+    return {
+      length: val.PrecisionAndScale[0],
+      scale: val.PrecisionAndScale[1],
+    };
+  }
+  return null;
+}
+
+export function getTableName(objectName) {
+  const last = objectName[objectName.length - 1];
+  return last?.Identifier?.value || last?.value || "";
+}
+
+export function getIndexColumnName(col) {
+  const expr = col.column?.expr || col.expr;
+  if (!expr) return "";
+  return expr.Identifier?.value || expr.value || "";
+}
+
+export function mapReferentialAction(action) {
+  const map = {
+    Cascade: "Cascade",
+    SetNull: "Set null",
+    SetDefault: "Set default",
+    NoAction: "No action",
+    Restrict: "Restrict",
+  };
+  return map[action] || "No action";
+}
+
+export function extractDefaultValue(expr) {
+  if (!expr) return "";
+
+  if (expr.Value) {
+    const val = expr.Value.value ?? expr.Value;
+    if (val === "Null") return "NULL";
+    if (val.SingleQuotedString !== undefined) return val.SingleQuotedString;
+    if (val.DoubleQuotedString !== undefined) return val.DoubleQuotedString;
+    if (val.Number) return val.Number[0];
+    if (val.Boolean !== undefined) return val.Boolean.toString().toUpperCase();
+    return val.toString();
+  }
+
+  if (expr.Function) {
+    const name = expr.Function.name
+      .map((n) => n.Identifier?.value || n.value || "")
+      .join(".");
+    if (expr.Function.args === "None" || !expr.Function.args) {
+      return name;
+    }
+    const args = Array.isArray(expr.Function.args) ? expr.Function.args : [];
+    const argStrs = args
+      .map((a) => {
+        const argExpr = a.Unnamed?.Expr || a.Unnamed || a;
+        return extractDefaultValue(argExpr);
+      })
+      .filter(Boolean);
+    return argStrs.length > 0 ? `${name}(${argStrs.join(", ")})` : name;
+  }
+
+  if (expr.Cast) {
+    return extractDefaultValue(expr.Cast.expr);
+  }
+
+  if (expr.UnaryOp) {
+    const operand = extractDefaultValue(expr.UnaryOp.expr);
+    if (expr.UnaryOp.op === "Minus") return `-${operand}`;
+    return operand;
+  }
+
+  if (expr.Array) {
+    const elems = expr.Array.elem
+      .map((e) => extractDefaultValue(e))
+      .join(", ");
+    return `ARRAY[${elems}]`;
+  }
+
+  if (expr.Identifier) {
+    return expr.Identifier.value;
+  }
+
+  if (typeof expr === "string") return expr;
+
+  return "";
+}
+
+export function getCustomTypeArgs(dataType) {
+  if (typeof dataType !== "object") return null;
+  if (!dataType.Custom) return null;
+  const [, args] = dataType.Custom;
+  return args;
 }

--- a/src/utils/importSQL/sqlite.js
+++ b/src/utils/importSQL/sqlite.js
@@ -1,7 +1,15 @@
 import { nanoid } from "nanoid";
 import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import {
+  buildSQLFromAST,
+  extractDefaultValue,
+  getTableName,
+  getTypeName,
+  getTypeSize,
+  getIndexColumnName,
+  mapReferentialAction,
+} from "./shared";
 
 const affinity = {
   [DB.SQLITE]: new Proxy(
@@ -41,181 +49,156 @@ export function fromSQLite(ast, diagramDb = DB.GENERIC) {
   const tables = [];
   const relationships = [];
 
-  const addRelationshipFromReferenceDef = (
-    startTable,
-    startFieldName,
-    referenceDefinition,
-  ) => {
-    const relationship = {};
-    const endTableName = referenceDefinition.table[0].table;
-    const endFieldName = referenceDefinition.definition[0].column;
+  const addRelationshipFromFK = (startTable, startFieldName, fk) => {
+    const endTableName = getTableName(fk.foreign_table);
+    const endFieldName = fk.referred_columns[0]?.value;
 
     const endTable = tables.find((t) => t.name === endTableName);
     if (!endTable) return;
-
     const endField = endTable.fields.find((f) => f.name === endFieldName);
     if (!endField) return;
-
-    const startField = startTable.fields.find((f) => f.name === startFieldName);
+    const startField = startTable.fields.find(
+      (f) => f.name === startFieldName,
+    );
     if (!startField) return;
 
-    relationship.name =
-      "fk_" + startTable.name + "_" + startFieldName + "_" + endTableName;
+    const relationship = {};
+    relationship.name = `fk_${startTable.name}_${startFieldName}_${endTableName}`;
     relationship.startTableId = startTable.id;
     relationship.endTableId = endTable.id;
     relationship.endFieldId = endField.id;
     relationship.startFieldId = startField.id;
     relationship.id = nanoid();
-
-    let updateConstraint = "No action";
-    let deleteConstraint = "No action";
-    referenceDefinition.on_action.forEach((c) => {
-      if (c.type === "on update") {
-        updateConstraint = c.value.value;
-        updateConstraint =
-          updateConstraint[0].toUpperCase() + updateConstraint.substring(1);
-      } else if (c.type === "on delete") {
-        deleteConstraint = c.value.value;
-        deleteConstraint =
-          deleteConstraint[0].toUpperCase() + deleteConstraint.substring(1);
-      }
-    });
-
-    relationship.updateConstraint = updateConstraint;
-    relationship.deleteConstraint = deleteConstraint;
+    relationship.updateConstraint = mapReferentialAction(fk.on_update);
+    relationship.deleteConstraint = mapReferentialAction(fk.on_delete);
 
     if (startField.unique) {
       relationship.cardinality = Cardinality.ONE_TO_ONE;
     } else {
       relationship.cardinality = Cardinality.MANY_TO_ONE;
     }
+
     relationships.push(relationship);
   };
 
-  const parseSingleStatement = (e) => {
-    if (e.type === "create") {
-      if (e.keyword === "table") {
-        const table = {};
-        table.name = e.table[0].table;
-        table.comment = "";
-        table.color = "#175e7a";
-        table.fields = [];
-        table.indices = [];
-        table.id = nanoid();
-        e.create_definitions.forEach((d) => {
-          if (d.resource === "column") {
-            const field = {};
-            field.id = nanoid();
-            field.name = d.column.column;
+  const parseSingleStatement = (stmt) => {
+    if (stmt.CreateTable) {
+      const ct = stmt.CreateTable;
+      const table = {};
+      table.name = getTableName(ct.name);
+      table.comment = "";
+      table.color = "#175e7a";
+      table.fields = [];
+      table.indices = [];
+      table.id = nanoid();
 
-            let type = d.definition.dataType;
-            if (!dbToTypes[diagramDb][type]) {
-              type = affinity[diagramDb][type];
-            }
-            field.type = type;
+      ct.columns.forEach((col) => {
+        const field = {};
+        field.id = nanoid();
+        field.name = col.name.value;
 
-            if (d.definition.expr && d.definition.expr.type === "expr_list") {
-              field.values = d.definition.expr.value.map((v) => v.value);
-            }
-            field.comment = d.comment ? d.comment.value.value : "";
-            field.unique = false;
-            if (d.unique) field.unique = true;
-            field.increment = false;
-            if (d.auto_increment) field.increment = true;
-            field.notNull = false;
-            if (d.nullable) field.notNull = true;
-            field.primary = false;
-            if (d.primary_key) field.primary = true;
-            field.default = "";
-            if (d.default_val) {
-              let defaultValue = "";
-              if (d.default_val.value.type === "function") {
-                defaultValue = d.default_val.value.name.name[0].value;
-                if (d.default_val.value.args) {
-                  defaultValue +=
-                    "(" +
-                    d.default_val.value.args.value
-                      .map((v) => {
-                        if (
-                          v.type === "single_quote_string" ||
-                          v.type === "double_quote_string"
-                        )
-                          return "'" + v.value + "'";
-                        return v.value;
-                      })
-                      .join(", ") +
-                    ")";
-                }
-              } else if (d.default_val.value.type === "null") {
-                defaultValue = "NULL";
-              } else {
-                defaultValue = d.default_val.value.value.toString();
-              }
-              field.default = defaultValue;
-            }
-            if (d.definition["length"]) {
-              if (d.definition.scale) {
-                field.size = d.definition["length"] + "," + d.definition.scale;
-              } else {
-                field.size = d.definition["length"];
-              }
-            }
-            field.check = "";
-            if (d.check) {
-              field.check = buildSQLFromAST(d.check.definition[0], DB.SQLITE);
-            }
-            table.fields.push(field);
+        let type = getTypeName(col.data_type);
+        if (!dbToTypes[diagramDb][type]) {
+          type = affinity[diagramDb][type];
+        }
+        field.type = type;
 
-            if (d.reference_definition) {
-              addRelationshipFromReferenceDef(
-                table,
-                field.name,
-                d.reference_definition,
-              );
-            }
-          } else if (d.resource === "constraint") {
-            if (d.constraint_type === "primary key") {
-              d.definition.forEach((c) => {
-                table.fields.forEach((f) => {
-                  if (f.name === c.column && !f.primary) {
-                    f.primary = true;
-                  }
-                });
-              });
-            } else if (d.constraint_type.toLowerCase() === "foreign key") {
-              addRelationshipFromReferenceDef(
-                table,
-                d.definition[0].column,
-                d.reference_definition,
-              );
+        if (col.data_type?.Enum) {
+          const [variants] = col.data_type.Enum;
+          field.values = variants.map((v) => v.Name || v.value || v);
+        }
+
+        field.comment = "";
+        field.unique = false;
+        field.increment = false;
+        field.notNull = false;
+        field.primary = false;
+        field.default = "";
+        field.check = "";
+
+        const size = getTypeSize(col.data_type);
+        if (size) {
+          field.size = size.scale
+            ? `${size.length},${size.scale}`
+            : `${size.length}`;
+        }
+
+        let inlineFk = null;
+
+        col.options.forEach((opt) => {
+          const o = opt.option;
+          if (o === "NotNull") field.notNull = true;
+          if (o === "Null") field.notNull = false;
+          if (o.PrimaryKey) field.primary = true;
+          if (o.Unique) field.unique = true;
+          if (o === "AutoIncrement") field.increment = true;
+          if (o.DialectSpecific) {
+            const tokens = o.DialectSpecific;
+            if (
+              tokens.some(
+                (t) =>
+                  t.Word?.keyword === "AUTOINCREMENT" ||
+                  t.Word?.keyword === "AUTO_INCREMENT",
+              )
+            ) {
+              field.increment = true;
             }
           }
+          if (o.Default) field.default = extractDefaultValue(o.Default);
+          if (o.Check) field.check = buildSQLFromAST(o.Check.expr, DB.SQLITE);
+          if (o.Comment !== undefined && typeof o.Comment === "string")
+            field.comment = o.Comment;
+          if (o.ForeignKey) {
+            inlineFk = o.ForeignKey;
+          }
         });
-        tables.push(table);
-      } else if (e.keyword === "index") {
-        const index = {
-          name: e.index,
-          unique: e.index_type === "unique",
-          fields: e.index_columns.map((f) => f.column),
-        };
 
-        const table = tables.find((t) => t.name === e.table.table);
+        table.fields.push(field);
 
-        if (table) {
-          table.indices.push(index);
-          table.indices.forEach((i, j) => {
-            i.id = j;
-          });
+        if (inlineFk) {
+          addRelationshipFromFK(table, field.name, inlineFk);
         }
+      });
+
+      ct.constraints.forEach((c) => {
+        if (c.PrimaryKey) {
+          c.PrimaryKey.columns.forEach((pk) => {
+            const colName = getIndexColumnName(pk);
+            table.fields.forEach((f) => {
+              if (f.name === colName && !f.primary) {
+                f.primary = true;
+              }
+            });
+          });
+        } else if (c.ForeignKey) {
+          const fk = c.ForeignKey;
+          const startFieldName = fk.columns[0]?.value;
+          addRelationshipFromFK(table, startFieldName, fk);
+        }
+      });
+
+      tables.push(table);
+    } else if (stmt.CreateIndex) {
+      const ci = stmt.CreateIndex;
+      const tableName = getTableName(ci.table_name);
+      const indexName = ci.name ? getTableName(ci.name) : "";
+      const index = {
+        name: indexName,
+        unique: ci.unique,
+        fields: ci.columns.map((c) => getIndexColumnName(c)),
+      };
+
+      const table = tables.find((t) => t.name === tableName);
+      if (table) {
+        table.indices.push(index);
+        table.indices.forEach((i, j) => {
+          i.id = j;
+        });
       }
     }
   };
 
-  if (Array.isArray(ast)) {
-    ast.forEach((e) => parseSingleStatement(e));
-  } else {
-    parseSingleStatement(ast);
-  }
+  ast.forEach((stmt) => parseSingleStatement(stmt));
 
   return { tables, relationships };
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    exclude: ['@guanmingchiu/sqlparser-ts'],
+  },
 })

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./src/utils/importSQL/__tests__/setup.js"],
+  },
+});


### PR DESCRIPTION
Replaced [node-sql-parser](https://github.com/taozhi8833998/node-sql-parser) + [oracle-sql-parser](https://github.com/niclasgelin/oracle-sql-parser) with [sqlparser-ts](https://github.com/guan404ming/sqlparser-ts), a WASM-powered SQL parser wrapping Rust's [sqlparser](https://crates.io/crates/sqlparser) from [Apache DataFusion](https://github.com/apache/datafusion-sqlparser-rs). It offers superior performance with zero JS/TS dependencies. 

The pkg was developed by me and officially adopted by Apache Airflow, this package has proven its stability in production environments.


More detailed bench -> https://github.com/guan404ming/sqlparser-ts/tree/main/benchmark