### PR TITLE
Add MYPRIMETYPE and layout stats box

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -14,6 +14,7 @@ import Table from "./Table";
 import Area from "./Area";
 import Relationship from "./Relationship";
 import Note from "./Note";
+import StatsBox from "./StatsBox";
 import {
   useCanvas,
   useSettings,
@@ -793,6 +794,7 @@ export default function Canvas() {
           )}
         </svg>
       </div>
+      <StatsBox />
       {settings.showDebugCoordinates && (
         <div className="fixed flex flex-col flex-wrap gap-6 bg-[rgba(var(--semi-grey-1),var(--tw-bg-opacity))]/40 border border-color bottom-4 right-4 p-4 rounded-xl backdrop-blur-xs pointer-events-none select-none">
           <table className="table-auto grow">

--- a/src/components/EditorCanvas/StatsBox.jsx
+++ b/src/components/EditorCanvas/StatsBox.jsx
@@ -1,0 +1,148 @@
+import { useMemo } from "react";
+import { useDiagram, useSettings } from "../../hooks";
+import { getTableHeight } from "../../utils/utils";
+
+function buildGraphStats(tableIds, relationships) {
+  const ids = new Set(tableIds);
+  const outgoing = new Map();
+  const undirected = new Map();
+
+  tableIds.forEach((id) => {
+    outgoing.set(id, new Set());
+    undirected.set(id, new Set());
+  });
+
+  relationships.forEach((rel) => {
+    if (!ids.has(rel.startTableId) || !ids.has(rel.endTableId)) return;
+    outgoing.get(rel.startTableId).add(rel.endTableId);
+    undirected.get(rel.startTableId).add(rel.endTableId);
+    undirected.get(rel.endTableId).add(rel.startTableId);
+  });
+
+  const isolatedTables = tableIds.filter((id) => undirected.get(id).size === 0);
+
+  const seen = new Set();
+  let connectedComponents = 0;
+  tableIds.forEach((id) => {
+    if (seen.has(id)) return;
+    connectedComponents += 1;
+    const stack = [id];
+    seen.add(id);
+    while (stack.length > 0) {
+      const current = stack.pop();
+      undirected.get(current).forEach((next) => {
+        if (seen.has(next)) return;
+        seen.add(next);
+        stack.push(next);
+      });
+    }
+  });
+
+  const state = new Map();
+  const memo = new Map();
+  const depthFrom = (id) => {
+    if (state.get(id) === 1) return 0;
+    if (state.get(id) === 2) return memo.get(id);
+
+    state.set(id, 1);
+    let best = 1;
+    outgoing.get(id).forEach((next) => {
+      best = Math.max(best, 1 + depthFrom(next));
+    });
+    state.set(id, 2);
+    memo.set(id, best);
+    return best;
+  };
+
+  const maxDepth =
+    tableIds.length > 0 ? Math.max(...tableIds.map((id) => depthFrom(id))) : 0;
+
+  const maxOutDegree =
+    tableIds.length > 0
+      ? Math.max(...tableIds.map((id) => outgoing.get(id).size))
+      : 0;
+
+  return {
+    maxDepth,
+    maxOutDegree,
+    connectedComponents,
+    isolatedTables: isolatedTables.length,
+  };
+}
+
+export default function StatsBox() {
+  const { tables, relationships } = useDiagram();
+  const { settings } = useSettings();
+
+  const stats = useMemo(() => {
+    const tableIds = tables.map((table) => table.id);
+    const fieldsCount = tables.reduce(
+      (acc, table) => acc + (table.fields?.length ?? 0),
+      0,
+    );
+    const avgFieldsPerTable =
+      tables.length > 0 ? fieldsCount / tables.length : 0;
+
+    let width = 0;
+    let height = 0;
+    if (tables.length > 0) {
+      let minX = Number.POSITIVE_INFINITY;
+      let minY = Number.POSITIVE_INFINITY;
+      let maxX = Number.NEGATIVE_INFINITY;
+      let maxY = Number.NEGATIVE_INFINITY;
+
+      tables.forEach((table) => {
+        const tableHeight = getTableHeight(
+          table,
+          settings.tableWidth,
+          settings.showComments,
+        );
+        minX = Math.min(minX, table.x);
+        minY = Math.min(minY, table.y);
+        maxX = Math.max(maxX, table.x + settings.tableWidth);
+        maxY = Math.max(maxY, table.y + tableHeight);
+      });
+
+      width = maxX - minX;
+      height = maxY - minY;
+    }
+
+    return {
+      tables: tables.length,
+      relationships: relationships.length,
+      fieldsCount,
+      avgFieldsPerTable,
+      boundingWidth: width,
+      boundingHeight: height,
+      ...buildGraphStats(tableIds, relationships),
+    };
+  }, [relationships, settings.showComments, settings.tableWidth, tables]);
+
+  return (
+    <div className="fixed bottom-4 left-4 rounded-xl border border-color bg-[rgba(var(--semi-grey-1),var(--tw-bg-opacity))]/50 p-3 text-xs backdrop-blur-xs select-none pointer-events-none">
+      <div className="mb-2 text-sm font-semibold">Layout Stats</div>
+      <div className="grid grid-cols-[auto_auto] gap-x-4 gap-y-1">
+        <span>Tables</span>
+        <span className="text-right">{stats.tables}</span>
+        <span>Relationships</span>
+        <span className="text-right">{stats.relationships}</span>
+        <span>Total Fields</span>
+        <span className="text-right">{stats.fieldsCount}</span>
+        <span>Avg Fields / Table</span>
+        <span className="text-right">{stats.avgFieldsPerTable.toFixed(2)}</span>
+        <span>Max Depth</span>
+        <span className="text-right">{stats.maxDepth}</span>
+        <span>Max Out-degree</span>
+        <span className="text-right">{stats.maxOutDegree}</span>
+        <span>Components</span>
+        <span className="text-right">{stats.connectedComponents}</span>
+        <span>Isolated Tables</span>
+        <span className="text-right">{stats.isolatedTables}</span>
+        <span>Bounding Width</span>
+        <span className="text-right">{stats.boundingWidth.toFixed(0)}</span>
+        <span>Bounding Height</span>
+        <span className="text-right">{stats.boundingHeight.toFixed(0)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -18,6 +18,12 @@ import { DB } from "./constants";
 const intRegex = /^-?\d*$/;
 const doubleRegex = /^-?\d*.?\d+$/;
 const binaryRegex = /^[01]+$/;
+const myPrimeTypeRegex = /^[1-9]\d*$/;
+
+const isMyPrimeTypeValue = (value) => {
+  if (!myPrimeTypeRegex.test(value)) return false;
+  return Number.parseInt(value, 10) % 2 === 1;
+};
 
 /* eslint-disable no-unused-vars */
 const defaultTypesBase = {
@@ -31,6 +37,14 @@ const defaultTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => isMyPrimeTypeValue(field.default),
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   SMALLINT: {
     type: "SMALLINT",
@@ -364,6 +378,14 @@ const mysqlTypesBase = {
     hasPrecision: false,
     canIncrement: true,
     signed: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => isMyPrimeTypeValue(field.default),
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   SMALLINT: {
     type: "SMALLINT",
@@ -829,6 +851,14 @@ const postgresTypesBase = {
     hasPrecision: false,
     canIncrement: true,
     compatibleWith: ["SMALLSERIAL", "SERIAL", "BIGSERIAL", "INTEGER", "BIGINT"],
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => isMyPrimeTypeValue(field.default),
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   INTEGER: {
     type: "INTEGER",
@@ -1418,6 +1448,14 @@ const sqliteTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => isMyPrimeTypeValue(field.default),
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+  },
   REAL: {
     type: "REAL",
     color: decimalColor,
@@ -1566,6 +1604,14 @@ const mssqlTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => isMyPrimeTypeValue(field.default),
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   SMALLINT: {
     type: "SMALLINT",
@@ -1987,6 +2033,14 @@ const oraclesqlTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => isMyPrimeTypeValue(field.default),
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   NUMBER: {
     type: "NUMBER",


### PR DESCRIPTION

1) New datatype: `MYPRIMETYPE`
- Added `MYPRIMETYPE` to datatype maps so it is available in the editor/type selectors.
- Added validation logic for defaults:
  - accepts positive odd integers (`1, 3, 5, 7, 9, 11, ...`) per requested pattern.
- Integrated across DB maps to avoid export/import/check issues when switching dialects.


2) New Layout Stats Box
- Added `StatsBox` component to the editor canvas.
- Displays live layout/graph stats:
  - number of tables
  - number of relationships
  - total fields
  - average fields per table
  - max depth
  - max out-degree
  - connected components
  - isolated tables
  - bounding width / bounding height