### PR TITLE
new datatype

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -18,6 +18,17 @@ import { DB } from "./constants";
 const intRegex = /^-?\d*$/;
 const doubleRegex = /^-?\d*.?\d+$/;
 const binaryRegex = /^[01]+$/;
+const positiveIntegerRegex = /^[1-9]\d*$/;
+const isMyPrimeTypeValue = (value) =>
+  positiveIntegerRegex.test(value) && Number.parseInt(value, 10) % 2 === 1;
+const myPrimeType = {
+  type: "MYPRIMETYPE",
+  color: intColor,
+  checkDefault: (field) => isMyPrimeTypeValue(field.default),
+  hasCheck: true,
+  isSized: false,
+  hasPrecision: false,
+};
 
 /* eslint-disable no-unused-vars */
 const defaultTypesBase = {
@@ -54,6 +65,7 @@ const defaultTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: myPrimeType,
   DECIMAL: {
     type: "DECIMAL",
     color: decimalColor,
@@ -413,6 +425,7 @@ const mysqlTypesBase = {
     canIncrement: true,
     signed: true,
   },
+  MYPRIMETYPE: myPrimeType,
   DECIMAL: {
     type: "DECIMAL",
     color: decimalColor,
@@ -866,6 +879,7 @@ const postgresTypesBase = {
       "SMALLINT",
     ],
   },
+  MYPRIMETYPE: myPrimeType,
   DECIMAL: {
     type: "DECIMAL",
     color: decimalColor,
@@ -1418,6 +1432,7 @@ const sqliteTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: myPrimeType,
   REAL: {
     type: "REAL",
     color: decimalColor,
@@ -1600,6 +1615,7 @@ const mssqlTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: myPrimeType,
   BIT: {
     type: "BIT",
     color: binaryColor,
@@ -2020,6 +2036,7 @@ const oraclesqlTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: myPrimeType,
   VARCHAR2: {
     type: "VARCHAR2",
     color: stringColor,


### PR DESCRIPTION
Summary
Adds a new custom datatype MYPRIMETYPE to the editor’s datatype catalog across supported SQL dialect maps.

What Changed
Introduced shared MYPRIMETYPE metadata in [datatypes.js](app://-/index.html?hostId=local#).
Added default-value validation for MYPRIMETYPE to accept the sequence requested: positive odd integers (1, 3, 5, 7, 9, 11, ...).
Registered MYPRIMETYPE in:
defaultTypesBase
mysqlTypesBase
postgresTypesBase
sqliteTypesBase
mssqlTypesBase
oraclesqlTypesBase
Behavior
MYPRIMETYPE now appears in datatype selection UIs for the mapped databases.
Default value checks (checkDefault) now validate MYPRIMETYPE values against the allowed sequence.
Validation
[datatypes.js](app://-/index.html?hostId=local#) passes.
Notes
This implementation follows the provided sequence literally (1, 3, 5, 7, 9, 11, ...).
If strict mathematical primes are intended, validation can be updated in a follow-up (which would exclude 1 and 9).