### PR TITLE
added 2 new features

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -34,7 +34,7 @@ export default function Table({
   const [hoveredField, setHoveredField] = useState(null);
   const { database } = useDiagram();
   const { layout } = useLayout();
-  const { deleteTable, deleteField, updateTable } = useDiagram();
+  const { deleteTable, deleteField, deleteAllFields, updateTable } = useDiagram();
   const { settings } = useSettings();
   const { t } = useTranslation();
   const {
@@ -64,6 +64,11 @@ export default function Table({
       )
     );
   }, [selectedElement, tableData, bulkSelectedElements]);
+
+  const handleDeleteAllFields = () => {
+    if (layout.readOnly) return;
+    deleteAllFields(tableData.id);
+  };
 
   const lockUnlockTable = (e) => {
     const locking = !tableData.locked;
@@ -242,6 +247,15 @@ export default function Table({
                             </div>
                           )}
                         </div>
+                        <Button
+                          type="warning"
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={handleDeleteAllFields}
+                          disabled={layout.readOnly || tableData.fields.length === 0}
+                        >
+                          {t("delete_all_fields")}
+                        </Button>
                         <Button
                           icon={<IconDeleteStroked />}
                           type="danger"

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -110,6 +110,7 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
     updateTable,
     deleteField,
     deleteTable,
+    deleteAllFields,
     updateField,
     setRelationships,
     addRelationship,
@@ -249,6 +250,9 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           });
         } else if (a.component === "self") {
           updateTable(a.tid, a.undo);
+        } else if (a.component === "fields_delete_all") {
+          setRelationships((prev) => [...prev, ...a.data.relationship]);
+          updateTable(a.tid, { fields: a.data.fields });
         }
       } else if (a.element === ObjectType.RELATIONSHIP) {
         updateRelationship(a.rid, a.undo);
@@ -430,6 +434,8 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           });
         } else if (a.component === "self") {
           updateTable(a.tid, a.redo, false);
+        } else if (a.component === "fields_delete_all") {
+          deleteAllFields(a.tid, false);
         }
       } else if (a.element === ObjectType.RELATIONSHIP) {
         updateRelationship(a.rid, a.redo);

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -173,6 +173,59 @@ export default function DiagramContextProvider({ children }) {
     });
   };
 
+  const deleteAllFields = (tid, addToHistory = true) => {
+    const table = tables.find((t) => t.id === tid);
+    if (!table) return;
+
+    const { fields, name } = table;
+    if (fields.length === 0) return;
+
+    const fieldIds = fields.map((f) => f.id);
+
+    const rels = relationships.reduce((acc, r) => {
+      if (
+        (r.startTableId === tid && fieldIds.includes(r.startFieldId)) ||
+        (r.endTableId === tid && fieldIds.includes(r.endFieldId))
+      ) {
+        acc.push(r);
+      }
+      return acc;
+    }, []);
+
+    if (addToHistory) {
+      setUndoStack((prev) => [
+        ...prev,
+        {
+          action: Action.EDIT,
+          element: ObjectType.TABLE,
+          component: "fields_delete_all",
+          tid,
+          data: {
+            fields,
+            relationship: rels,
+          },
+          message: t("edit_table", {
+            tableName: name,
+            extra: "[delete all fields]",
+          }),
+        },
+      ]);
+      setRedoStack([]);
+    }
+
+    setRelationships((prev) =>
+      prev.filter(
+        (e) =>
+          !(
+            (e.startTableId === tid && fieldIds.includes(e.startFieldId)) ||
+            (e.endTableId === tid && fieldIds.includes(e.endFieldId))
+          ),
+      ),
+    );
+
+    updateTable(tid, { fields: [] });
+  };
+
   const addRelationship = (data, addToHistory = true) => {
     if (addToHistory) {
       setRelationships((prev) => {
@@ -237,6 +290,7 @@ export default function DiagramContextProvider({ children }) {
         updateTable,
         updateField,
         deleteField,
+        deleteAllFields,
         deleteTable,
         relationships,
         setRelationships,

--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -115,6 +115,18 @@ const defaultTypesBase = {
     isSized: false,
     hasPrecision: false,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+  },
   CHAR: {
     type: "CHAR",
     color: stringColor,
@@ -413,6 +425,18 @@ const mysqlTypesBase = {
     canIncrement: true,
     signed: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+  },
   DECIMAL: {
     type: "DECIMAL",
     color: decimalColor,
@@ -462,6 +486,18 @@ const mysqlTypesBase = {
     hasCheck: true,
     isSized: false,
     hasPrecision: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   BOOLEAN: {
     type: "BOOLEAN",
@@ -865,6 +901,18 @@ const postgresTypesBase = {
       "INTEGER",
       "SMALLINT",
     ],
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   DECIMAL: {
     type: "DECIMAL",
@@ -1600,6 +1648,18 @@ const mssqlTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+  },
   BIT: {
     type: "BIT",
     color: binaryColor,
@@ -2019,6 +2079,18 @@ const oraclesqlTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   VARCHAR2: {
     type: "VARCHAR2",

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -279,6 +279,7 @@ const en = {
     insert_sql: "Insert SQL",
     upload_file: "Upload file",
     show_comments: "Show comments",
+    delete_all_fields: "Delete all fields",
   },
 };
 

--- a/src/utils/exportSQL/generic.js
+++ b/src/utils/exportSQL/generic.js
@@ -10,6 +10,7 @@ export function getJsonType(f) {
     case "INT":
     case "SMALLINT":
     case "BIGINT":
+    case "MYPRIMETYPE":
     case "DECIMAL":
     case "NUMERIC":
     case "REAL":
@@ -50,6 +51,9 @@ export function getTypeString(
     if (field.type === "UUID") {
       return `VARCHAR(36)`;
     }
+    if (field.type === "MYPRIMETYPE") {
+      return "INT";
+    }
     if (
       dbToTypes[currentDb][field.type].isSized ||
       dbToTypes[currentDb][field.type].hasPrecision
@@ -64,6 +68,9 @@ export function getTypeString(
     }
     return field.type;
   } else if (dbms === DB.POSTGRES) {
+    if (field.type === "MYPRIMETYPE") {
+      return "integer";
+    }
     if (field.type === "SMALLINT" && field.increment) {
       return "smallserial";
     }
@@ -105,6 +112,8 @@ export function getTypeString(
   } else if (dbms === DB.MSSQL) {
     let type = field.type;
     switch (field.type) {
+      case "MYPRIMETYPE":
+        return "INT";
       case "ENUM":
         return baseType
           ? "NVARCHAR(255)"
@@ -142,6 +151,9 @@ export function getTypeString(
   } else if (dbms === DB.ORACLESQL) {
     let oracleType;
     switch (field.type) {
+      case "MYPRIMETYPE":
+        oracleType = "NUMBER";
+        break;
       case "BIGINT":
         oracleType = "NUMBER";
         break;
@@ -357,6 +369,7 @@ export function getSQLiteType(field) {
     case "INT":
     case "SMALLINT":
     case "BIGINT":
+    case "MYPRIMETYPE":
     case "BOOLEAN":
       return "INTEGER";
     case "DECIMAL":


### PR DESCRIPTION
Introduces a "Delete All Fields" feature with full undo/redo support and adds a new custom data type, MYPRIMETYPE, integrated across the UI and SQL export logic.

Key Changes
1. "Delete All Fields" Feature
Context: Added deleteAllFields to DiagramContext.jsx to clear a table while automatically removing associated relationships.

UI: Added a "Delete all fields" button in Table.jsx with a warning style.

History: Integrated with ControlPanel.jsx to support Undo/Redo actions for bulk deletions.

2. Data Type: MYPRIMETYPE
Definition: Added to datatypes.js with custom validation (positive odd integers only).

SQL Mapping: Updated generic.js to map MYPRIMETYPE to native types:

Postgres: integer

Oracle: NUMBER

MySQL/MSSQL: INT

SQLite: INTEGER