### PR TITLE
Implements Feature A

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -19,6 +19,13 @@ const intRegex = /^-?\d*$/;
 const doubleRegex = /^-?\d*.?\d+$/;
 const binaryRegex = /^[01]+$/;
 
+const isMyPrimeTypeValue = (value) => {
+  const n = Number(value);
+  if (!Number.isInteger(n)) return false;
+  if (n <= 0) return false;
+  return n % 2 === 1;
+};
+
 /* eslint-disable no-unused-vars */
 const defaultTypesBase = {
   INT: {
@@ -83,6 +90,17 @@ const defaultTypesBase = {
     hasCheck: true,
     isSized: false,
     hasPrecision: true,
+    canIncrement: false,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: decimalColor,
+    checkDefault: (field) => {
+      return isMyPrimeTypeValue(field.default);
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
     canIncrement: false,
   },
   FLOAT: {

--- a/src/utils/exportSQL/generic.js
+++ b/src/utils/exportSQL/generic.js
@@ -7,6 +7,8 @@ export function getJsonType(f) {
     return '{ "type" : "object", additionalProperties : true }';
   }
   switch (f.type) {
+    case "MYPRIMETYPE":
+      return '{ "type" : "number" }';
     case "INT":
     case "SMALLINT":
     case "BIGINT":


### PR DESCRIPTION
New helper predicate in datatypes.js: isMyPrimeTypeValue

New datatype MYPRIMETYPE in the generic/default type set (defaultTypesBase):

This makes MYPRIMETYPE available when the diagram database is DB.GENERIC.

A value is valid for MYPRIMETYPE iff it is a positive odd integer (1, 3, 5, 7, 9, 11, …), matching your listed sequence.