### PR TITLE
Add a new datatype MYPRIMETYPE that supports a fixed set of prime num…

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -54,6 +54,32 @@ const defaultTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) {
+        return false;
+      }
+      const n = Number(field.default);
+      if (!Number.isInteger(n) || n < 1) {
+        return false;
+      }
+      if (n === 1) {
+        return true;
+      }
+      for (let i = 2; i * i <= n; i++) {
+        if (n % i === 0) {
+          return false;
+        }
+      }
+      return true;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
+  },
   DECIMAL: {
     type: "DECIMAL",
     color: decimalColor,


### PR DESCRIPTION
### Summary
Add custom numeric datatype MYPRIMETYPE that only allows defaults which are either 1 or a positive prime number, for use in table fields and custom types.
### Changes
Datatype definition:
- Added MYPRIMETYPE to the Generic database defaultTypesBase in datatypes.js.
- Reused intColor so it appears alongside other integer-like types in the UI.
Validation logic:
- Implemented checkDefault to:
     - Require the default to pass the existing integer regex.
     - Accept 1 explicitly.
     - For values greater than 1, perform a simple primality check and only accept primes.
- Marked MYPRIMETYPE with:
     - hasCheck: true so the default value is actively validated.
     - isSized: false, hasPrecision: false (no size/precision UI controls).
     - canIncrement: false to prevent use as an auto-increment column type.
### Testing Instructions
- Manual UI testing
     - Start the app and select the Generic database.
     - Create or open a table and add a new field.
     - In the type dropdown, select MYPRIMETYPE.
     - In the field details:
          - Set the default to 1, 3, 5, 7, 11 – the default input should remain in a valid state.
          - Try defaults like 4, 6, 8, 9, 10, -3, 1.5, or non-numeric strings – the default input should be treated as invalid according to the existing validation behavior (error state / red highlight, depending on current UI).
- Regression checks
     - Verify that existing types (e.g., INT, VARCHAR, BOOLEAN) still behave as before in the type dropdown and field details.
     - Confirm that switching between types and back to MYPRIMETYPE does not break undo/redo or type-specific controls.