### PR TITLE
Add MYPRIMETYPE datatype and delete-fields option

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -34,7 +34,8 @@ export default function Table({
   const [hoveredField, setHoveredField] = useState(null);
   const { database } = useDiagram();
   const { layout } = useLayout();
-  const { deleteTable, deleteField, updateTable } = useDiagram();
+  const { deleteTable, deleteField, deleteAllFields, updateTable } =
+    useDiagram();
   const { settings } = useSettings();
   const { t } = useTranslation();
   const {
@@ -242,6 +243,16 @@ export default function Table({
                             </div>
                           )}
                         </div>
+                        <Button
+                          icon={<IconDeleteStroked />}
+                          type="danger"
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={() => deleteAllFields(tableData.id)}
+                          disabled={layout.readOnly}
+                        >
+                          {t("delete_all_fields")}
+                        </Button>
                         <Button
                           icon={<IconDeleteStroked />}
                           type="danger"

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -127,6 +127,57 @@ export default function DiagramContextProvider({ children }) {
     );
   };
 
+  const deleteAllFields = (tid, addToHistory = true) => {
+    const table = tables.find((t) => t.id === tid);
+    if (!table || table.fields.length === 0) return;
+
+    if (addToHistory) {
+      const fieldIds = table.fields.map((f) => f.id);
+      const rels = relationships.reduce((acc, r) => {
+        if (
+          (r.startTableId === tid && fieldIds.includes(r.startFieldId)) ||
+          (r.endTableId === tid && fieldIds.includes(r.endFieldId))
+        ) {
+          acc.push(r);
+        }
+        return acc;
+      }, []);
+
+      setUndoStack((prev) => [
+        ...prev,
+        {
+          action: Action.EDIT,
+          element: ObjectType.TABLE,
+          component: "fields_delete_all",
+          tid,
+          data: {
+            fields: table.fields,
+            relationship: rels,
+          },
+          message: t("edit_table", {
+            tableName: table.name,
+            extra: "[delete all fields]",
+          }),
+        },
+      ]);
+      setRedoStack([]);
+    }
+
+    const fieldIds = new Set(table.fields.map((f) => f.id));
+    setRelationships((prev) =>
+      prev.filter(
+        (e) =>
+          !(
+            (e.startTableId === tid && fieldIds.has(e.startFieldId)) ||
+            (e.endTableId === tid && fieldIds.has(e.endFieldId))
+          ),
+      ),
+    );
+    updateTable(tid, {
+      fields: [],
+    });
+  };
+
   const deleteField = (field, tid, addToHistory = true) => {
     const { fields, name } = tables.find((t) => t.id === tid);
     if (addToHistory) {
@@ -238,6 +289,7 @@ export default function DiagramContextProvider({ children }) {
         updateField,
         deleteField,
         deleteTable,
+        deleteAllFields,
         relationships,
         setRelationships,
         addRelationship,

--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -54,6 +54,20 @@ const defaultTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      if (Number.isNaN(value)) return false;
+      return value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
+  },
   DECIMAL: {
     type: "DECIMAL",
     color: decimalColor,

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -126,6 +126,7 @@ const en = {
     check: "Check expression",
     this_will_appear_as_is: "*This will appear in the generated script as is.",
     comment: "Comment",
+    delete_all_fields: "Delete all fields",
     add_field: "Add field",
     values: "Values",
     size: "Size",


### PR DESCRIPTION
Introduce MYPRIMETYPE numeric datatype for generic diagrams and add a delete-all-fields action in table menu with proper undo handling.

Made-with: Cursor