### PR TITLE
Add MYPRIMETYPE datatype support

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -18,6 +18,7 @@ import { DB } from "./constants";
 const intRegex = /^-?\d*$/;
 const doubleRegex = /^-?\d*.?\d+$/;
 const binaryRegex = /^[01]+$/;
+const myPrimeTypeRegex = /^(?:[1-9]\d*)$/;
 
 /* eslint-disable no-unused-vars */
 const defaultTypesBase = {
@@ -31,6 +32,19 @@ const defaultTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!myPrimeTypeRegex.test(field.default)) return false;
+      const n = Number.parseInt(field.default, 10);
+      return n > 0 && n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
   },
   SMALLINT: {
     type: "SMALLINT",
@@ -364,6 +378,20 @@ const mysqlTypesBase = {
     hasPrecision: false,
     canIncrement: true,
     signed: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!myPrimeTypeRegex.test(field.default)) return false;
+      const n = Number.parseInt(field.default, 10);
+      return n > 0 && n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
+    signed: false,
   },
   SMALLINT: {
     type: "SMALLINT",
@@ -829,6 +857,18 @@ const postgresTypesBase = {
     hasPrecision: false,
     canIncrement: true,
     compatibleWith: ["SMALLSERIAL", "SERIAL", "BIGSERIAL", "INTEGER", "BIGINT"],
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!myPrimeTypeRegex.test(field.default)) return false;
+      const n = Number.parseInt(field.default, 10);
+      return n > 0 && n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   INTEGER: {
     type: "INTEGER",
@@ -1418,6 +1458,19 @@ const sqliteTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!myPrimeTypeRegex.test(field.default)) return false;
+      const n = Number.parseInt(field.default, 10);
+      return n > 0 && n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
+  },
   REAL: {
     type: "REAL",
     color: decimalColor,
@@ -1566,6 +1619,19 @@ const mssqlTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!myPrimeTypeRegex.test(field.default)) return false;
+      const n = Number.parseInt(field.default, 10);
+      return n > 0 && n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
   },
   SMALLINT: {
     type: "SMALLINT",
@@ -1987,6 +2053,19 @@ const oraclesqlTypesBase = {
     isSized: false,
     hasPrecision: false,
     canIncrement: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!myPrimeTypeRegex.test(field.default)) return false;
+      const n = Number.parseInt(field.default, 10);
+      return n > 0 && n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
   },
   NUMBER: {
     type: "NUMBER",


### PR DESCRIPTION
## Summary
- Added new builtin datatype \`MYPRIMETYPE\` in \`src/data/datatypes.js\`.
- Integrated it into Generic, MySQL, PostgreSQL, SQLite, MSSQL, and OracleSQL type maps.
- MariaDB support is included via its MySQL-based type map merge.
- Added validation so defaults accept the fixed odd-number sequence format (e.g. 1, 3, 5, 7, 9, 11, ...).

## Validation
- Ran lint successfully.

## Notes
- No UI component changes required; type appears via existing datatype registry usage." \