### PR TITLE
Add MYPRIMETYPE datatype and layout stats box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -420,6 +421,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1216,6 +1218,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.12.6.tgz",
       "integrity": "sha512-rJFp7tXzawCrMWWRsjCR80dZoIkLJ/EPgPmTk3xqpc+9ntlwbkm3LUOdFmgN+pshnhiZTQBwbFqg/QbsA1Pw9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/html": "0.12.6",
         "@lexical/list": "0.12.6",
@@ -1416,6 +1419,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.12.6.tgz",
       "integrity": "sha512-HJBEazVwOe6duyHV6+vB/MS4kUBlCV05Cfcigdx8HlLLFQRWPqHrTpaxKz4jfb9ar0SlI2W1BUNbySAxMkC/HQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "lexical": "0.12.6"
       }
@@ -1446,6 +1450,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.12.6.tgz",
       "integrity": "sha512-hK5r/TD2nH5TfWSiCxy7/lh0s11qJcI1wo++PBQOR9o937pQ+/Zr/1tMOc8MnrTpl89mtmYtPfWW3f++HH1Yog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/list": "0.12.6",
         "@lexical/selection": "0.12.6",
@@ -2405,6 +2410,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2503,6 +2509,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2847,6 +2854,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -3244,6 +3252,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -3383,6 +3392,7 @@
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.7.tgz",
       "integrity": "sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3733,6 +3743,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4696,6 +4707,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -5262,7 +5274,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5450,14 +5461,14 @@
       "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.12.6.tgz",
       "integrity": "sha512-Nlfjc+k9cIWpOMv7XufF0Mv09TAXSemNAuAqFLaOwTcN+RvhvYTDtVLSp9D9r+5I097fYs1Vf/UYwH2xEpkFfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lib0": {
       "version": "0.2.114",
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -7286,6 +7297,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7474,6 +7486,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7486,6 +7499,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8997,6 +9011,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/components/StatsBox.jsx
+++ b/src/components/StatsBox.jsx
@@ -1,0 +1,74 @@
+import { useDiagram } from "../hooks";
+
+function computeLongestChain(tables, relationships) {
+  if (!tables || tables.length <= 1) return 0;
+
+  const adjacency = new Map();
+  tables.forEach((table) => {
+    adjacency.set(table.id, new Set());
+  });
+
+  relationships.forEach((rel) => {
+    const { startTableId, endTableId } = rel;
+    if (!adjacency.has(startTableId) || !adjacency.has(endTableId)) return;
+    adjacency.get(startTableId).add(endTableId);
+    adjacency.get(endTableId).add(startTableId);
+  });
+
+  const bfsMaxDistance = (startId) => {
+    const visited = new Set([startId]);
+    const queue = [{ id: startId, dist: 0 }];
+    let maxDist = 0;
+
+    while (queue.length > 0) {
+      const { id, dist } = queue.shift();
+      maxDist = Math.max(maxDist, dist);
+      const neighbors = adjacency.get(id) ?? new Set();
+      neighbors.forEach((neighborId) => {
+        if (!visited.has(neighborId)) {
+          visited.add(neighborId);
+          queue.push({ id: neighborId, dist: dist + 1 });
+        }
+      });
+    }
+
+    return maxDist;
+  };
+
+  let longest = 0;
+  tables.forEach((table) => {
+    longest = Math.max(longest, bfsMaxDistance(table.id));
+  });
+
+  return longest;
+}
+
+export default function StatsBox() {
+  const { tables, relationships } = useDiagram();
+
+  const tableCount = tables.length;
+  const relationshipCount = relationships.length;
+  const maxChainLength = computeLongestChain(tables, relationships);
+
+  if (tableCount === 0 && relationshipCount === 0) {
+    return null;
+  }
+
+  return (
+    <div className="fixed left-5 bottom-4 flex flex-col gap-1 bg-[rgba(var(--semi-grey-1),var(--tw-bg-opacity))]/40 border border-color px-3 py-2 rounded-xl backdrop-blur-xs text-xs select-none">
+      <div className="font-semibold">Layout stats</div>
+      <div className="flex gap-4 flex-wrap">
+        <div>
+          <span className="font-medium">Tables:</span> {tableCount}
+        </div>
+        <div>
+          <span className="font-medium">Relationships:</span> {relationshipCount}
+        </div>
+        <div>
+          <span className="font-medium">Max chain length:</span> {maxChainLength}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, createContext } from "react";
 import ControlPanel from "./EditorHeader/ControlPanel";
 import Canvas from "./EditorCanvas/Canvas";
+import StatsBox from "./StatsBox";
 import { CanvasContextProvider } from "../context/CanvasContext";
 import SidePanel from "./EditorSidePanel/SidePanel";
 import { DB, State } from "../data/constants";
@@ -491,6 +492,7 @@ export default function WorkSpace() {
           <CanvasContextProvider className="h-full w-full">
             <Canvas saveState={saveState} setSaveState={setSaveState} />
           </CanvasContextProvider>
+          <StatsBox />
           {version && (
             <div className="absolute right-8 top-2 space-x-2">
               <Button

--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -32,6 +32,22 @@ const defaultTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (field.default === "") return true;
+      if (!intRegex.test(field.default)) return false;
+      const n = Number(field.default);
+      if (!Number.isInteger(n)) return false;
+      if (n <= 0) return false;
+      return n % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
+  },
   SMALLINT: {
     type: "SMALLINT",
     color: intColor,


### PR DESCRIPTION
Summary
Added a new built‑in datatype MYPRIMETYPE for the generic database that only accepts positive odd integers as valid default values.
Introduced a “Layout stats” box in the editor UI that displays live statistics about the current diagram (tables, relationships, and max chain length of connected tables).
Details of changes
New datatype: MYPRIMETYPE

Extended defaultTypesBase in src/data/datatypes.js with a new type MYPRIMETYPE.
Wired it into the existing dbToTypes mapping, so it automatically:
Appears in the field type dropdown in the Tables side panel when using the Generic database.
Integrates with existing field rendering in the canvas and field summary popovers.
Implemented a checkDefault function so:
Empty defaults are allowed.
Non‑empty defaults must be parseable as an integer.
The integer must be positive and odd (1, 3, 5, 7, 9, 11, …); even, zero, negative, or non‑numeric values are considered invalid.
Layout stats box

Added a new component StatsBox in src/components/StatsBox.jsx.
Uses useDiagram() to read the current diagram state:
Tables: number of tables in the diagram.
Relationships: number of relationships.
Max chain length: longest chain of connected tables, computed by:
Building an undirected adjacency map of table IDs from the relationships.
Running breadth‑first search (BFS) from each table to find the largest distance to any other reachable table.
Integrated StatsBox into Workspace so it renders as a small, fixed overlay near the canvas without interfering with the existing toolbar and side panel.
Testing instructions
Run the app

From the project root:
npm install        # if not already done
npm run dev
Open the app in your browser (e.g., http://localhost:5173).
Verify MYPRIMETYPE

Open or create a diagram using the Generic database.
Add a table or select an existing one, then open the Tables tab in the side panel.
For a field:
Open the Type dropdown and confirm that MYPRIMETYPE is present.
Try different default values:
Should be accepted: empty default, 1, 3, 5, 7, 9, 11, …
Should be rejected by validation: 0, 2, 4, 10, -1, 1.5, "abc", etc.
Verify the layout stats box

In the editor canvas, add a few tables and connect them with relationships.
Look near the bottom‑left of the canvas:
Confirm that the “Layout stats” box appears and shows:
Tables: <count>
Relationships: <count>
Max chain length: <value>
Add and remove tables and relationships:
The table and relationship counts should update immediately.
Create a chain of tables (e.g., A – B – C – D):
The Max chain length should increase as the chain gets longer, and decrease if you break connections.
Linting / tooling

If eslint is installed in your environment, optionally run:
npm run lint
Note: In the provided environment, eslint was not available (eslint: command not found), so no automated lint results are included in this PR.

Made with cursor