### PR TITLE
Add auto-arrange layout and canvas stats box

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -14,6 +14,7 @@ import Table from "./Table";
 import Area from "./Area";
 import Relationship from "./Relationship";
 import Note from "./Note";
+import StatsBox from "./StatsBox";
 import {
   useCanvas,
   useSettings,
@@ -685,7 +686,7 @@ export default function Canvas() {
   return (
     <div className="grow h-full touch-none" id="canvas">
       <div
-        className="w-full h-full"
+        className="w-full h-full relative"
         style={{
           cursor: pointer.style,
           backgroundColor: settings.mode === "dark" ? darkBgTheme : "white",
@@ -792,6 +793,7 @@ export default function Canvas() {
             />
           )}
         </svg>
+        <StatsBox />
       </div>
       {settings.showDebugCoordinates && (
         <div className="fixed flex flex-col flex-wrap gap-6 bg-[rgba(var(--semi-grey-1),var(--tw-bg-opacity))]/40 border border-color bottom-4 right-4 p-4 rounded-xl backdrop-blur-xs pointer-events-none select-none">

--- a/src/components/EditorCanvas/StatsBox.jsx
+++ b/src/components/EditorCanvas/StatsBox.jsx
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useDiagram, useSettings } from "../../hooks";
+import { calculateLayoutStats } from "../../utils/autoArrange";
+
+export default function StatsBox() {
+  const { tables, relationships } = useDiagram();
+  const { settings } = useSettings();
+
+  const stats = useMemo(
+    () =>
+      calculateLayoutStats({
+        tables,
+        relationships,
+        tableWidth: settings.tableWidth,
+      }),
+    [relationships, settings.tableWidth, tables],
+  );
+
+  return (
+    <div className="absolute top-3 right-3 z-20 rounded-lg border border-zinc-400/50 bg-zinc-900/70 text-zinc-100 px-3 py-2 text-xs backdrop-blur-sm select-none">
+      <div className="font-semibold uppercase tracking-wide text-[10px] text-zinc-300 mb-1">
+        Layout Stats
+      </div>
+      <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
+        <div>Tables</div>
+        <div className="text-right">{stats.tables}</div>
+        <div>Relationships</div>
+        <div className="text-right">{stats.relationships}</div>
+        <div>Max depth</div>
+        <div className="text-right">{stats.maxDepth}</div>
+        <div>Crossings</div>
+        <div className="text-right">{stats.crossings}</div>
+        <div>Components</div>
+        <div className="text-right">{stats.connectedComponents}</div>
+        <div>Isolated</div>
+        <div className="text-right">{stats.isolatedTables}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -85,6 +85,7 @@ import { getTableHeight } from "../../utils/utils";
 import { deleteFromCache, STORAGE_KEY } from "../../utils/cache";
 import { useLiveQuery } from "dexie-react-hooks";
 import { DateTime } from "luxon";
+import { autoArrangeTables, createAutoArrangeUndoEntry } from "../../utils/autoArrange";
 
 export default function ControlPanel({ title, setTitle, lastSaved }) {
   const { id: diagramId } = useParams();
@@ -565,6 +566,21 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
       zoom: scale,
       pan: { x: centerX, y: centerY },
     }));
+  };
+  const autoArrange = () => {
+    if (layout.readOnly || tables.length < 2) return;
+
+    const arranged = autoArrangeTables(tables, relationships, settings.tableWidth);
+    const changed = arranged.some((table) => {
+      const current = tables.find((t) => t.id === table.id);
+      return current && (current.x !== table.x || current.y !== table.y);
+    });
+    if (!changed) return;
+
+    setTables(arranged);
+    setUndoStack((prev) => [...prev, createAutoArrangeUndoEntry(tables, arranged)]);
+    setRedoStack([]);
+    setSaveState(State.SAVING);
   };
   const edit = () => {
     if (selectedElement.element === ObjectType.TABLE) {
@@ -1559,6 +1575,7 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
     preventDefault: true,
   });
   useHotkeys("mod+alt+w", fitWindow, { preventDefault: true });
+  useHotkeys("mod+alt+r", autoArrange, { preventDefault: true });
   useHotkeys("alt+e", toggleDBMLEditor, { preventDefault: true });
 
   return (
@@ -1750,6 +1767,16 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
               onClick={() => setSidesheet(SIDESHEET.VERSIONS)}
             >
               <i className="fa-solid fa-code-branch" />
+            </button>
+          </Tooltip>
+          <Divider layout="vertical" margin="8px" />
+          <Tooltip content="Auto arrange (Ctrl+Alt+R)" position="bottom">
+            <button
+              className="py-1 px-2 hover-2 rounded-sm text-xl -mt-0.5 disabled:opacity-50"
+              onClick={autoArrange}
+              disabled={layout.readOnly || tables.length < 2}
+            >
+              <i className="fa-solid fa-shuffle" />
             </button>
           </Tooltip>
           <Divider layout="vertical" margin="8px" />

--- a/src/utils/autoArrange.js
+++ b/src/utils/autoArrange.js
@@ -1,0 +1,293 @@
+import {
+  Action,
+  ObjectType,
+  gridSize,
+  tableFieldHeight,
+  tableHeaderHeight,
+} from "../data/constants";
+
+function getTableCenter(table, tableWidth) {
+  const estimatedHeight = tableHeaderHeight + table.fields.length * tableFieldHeight + 20;
+  return {
+    x: table.x + tableWidth / 2,
+    y: table.y + estimatedHeight / 2,
+  };
+}
+
+function ccw(a, b, c) {
+  return (c.y - a.y) * (b.x - a.x) > (b.y - a.y) * (c.x - a.x);
+}
+
+function segmentsIntersect(a, b, c, d) {
+  return ccw(a, c, d) !== ccw(b, c, d) && ccw(a, b, c) !== ccw(a, b, d);
+}
+
+export function countRelationshipCrossings(tables, relationships, tableWidth) {
+  if (relationships.length < 2 || tables.length < 2) return 0;
+
+  const centers = new Map(
+    tables.map((table) => [table.id, getTableCenter(table, tableWidth)]),
+  );
+
+  let crossings = 0;
+  for (let i = 0; i < relationships.length; i++) {
+    const a = relationships[i];
+    const aStart = centers.get(a.startTableId);
+    const aEnd = centers.get(a.endTableId);
+    if (!aStart || !aEnd) continue;
+
+    for (let j = i + 1; j < relationships.length; j++) {
+      const b = relationships[j];
+      if (
+        a.startTableId === b.startTableId ||
+        a.startTableId === b.endTableId ||
+        a.endTableId === b.startTableId ||
+        a.endTableId === b.endTableId
+      ) {
+        continue;
+      }
+
+      const bStart = centers.get(b.startTableId);
+      const bEnd = centers.get(b.endTableId);
+      if (!bStart || !bEnd) continue;
+
+      if (segmentsIntersect(aStart, aEnd, bStart, bEnd)) {
+        crossings++;
+      }
+    }
+  }
+  return crossings;
+}
+
+function buildAdjacency(tableIds, relationships, directed = true) {
+  const adjacency = new Map(tableIds.map((id) => [id, new Set()]));
+
+  relationships.forEach((rel) => {
+    if (!adjacency.has(rel.startTableId) || !adjacency.has(rel.endTableId)) {
+      return;
+    }
+    adjacency.get(rel.startTableId).add(rel.endTableId);
+    if (!directed) {
+      adjacency.get(rel.endTableId).add(rel.startTableId);
+    }
+  });
+  return adjacency;
+}
+
+function computeMaxDepth(tableIds, relationships) {
+  if (tableIds.length === 0) return 0;
+
+  const adjacency = buildAdjacency(tableIds, relationships, true);
+  let maxDepth = 0;
+
+  tableIds.forEach((start) => {
+    const queue = [{ id: start, depth: 0 }];
+    const visited = new Set([start]);
+    while (queue.length) {
+      const node = queue.shift();
+      maxDepth = Math.max(maxDepth, node.depth);
+      adjacency.get(node.id).forEach((next) => {
+        if (!visited.has(next)) {
+          visited.add(next);
+          queue.push({ id: next, depth: node.depth + 1 });
+        }
+      });
+    }
+  });
+
+  return maxDepth;
+}
+
+function computeConnectedComponents(tableIds, relationships) {
+  if (tableIds.length === 0) return 0;
+  const adjacency = buildAdjacency(tableIds, relationships, false);
+  const visited = new Set();
+  let components = 0;
+
+  tableIds.forEach((id) => {
+    if (visited.has(id)) return;
+    components++;
+    const stack = [id];
+    visited.add(id);
+    while (stack.length) {
+      const node = stack.pop();
+      adjacency.get(node).forEach((next) => {
+        if (!visited.has(next)) {
+          visited.add(next);
+          stack.push(next);
+        }
+      });
+    }
+  });
+  return components;
+}
+
+export function calculateLayoutStats({ tables, relationships, tableWidth }) {
+  const tableIds = tables.map((table) => table.id);
+  const connectedTableIds = new Set();
+  relationships.forEach((rel) => {
+    connectedTableIds.add(rel.startTableId);
+    connectedTableIds.add(rel.endTableId);
+  });
+
+  return {
+    tables: tables.length,
+    relationships: relationships.length,
+    isolatedTables: tables.filter((table) => !connectedTableIds.has(table.id)).length,
+    maxDepth: computeMaxDepth(tableIds, relationships),
+    connectedComponents: computeConnectedComponents(tableIds, relationships),
+    crossings: countRelationshipCrossings(tables, relationships, tableWidth),
+  };
+}
+
+function buildLayering(tables, relationships) {
+  const tableIds = tables.map((table) => table.id);
+  const incomingCount = new Map(tableIds.map((id) => [id, 0]));
+  const outgoing = new Map(tableIds.map((id) => [id, []]));
+
+  relationships.forEach((rel) => {
+    if (!outgoing.has(rel.startTableId) || !incomingCount.has(rel.endTableId)) {
+      return;
+    }
+    outgoing.get(rel.startTableId).push(rel.endTableId);
+    incomingCount.set(rel.endTableId, incomingCount.get(rel.endTableId) + 1);
+  });
+
+  const queue = tableIds.filter((id) => incomingCount.get(id) === 0);
+  const levels = new Map(tableIds.map((id) => [id, 0]));
+
+  while (queue.length) {
+    const node = queue.shift();
+    outgoing.get(node).forEach((neighbor) => {
+      levels.set(neighbor, Math.max(levels.get(neighbor), levels.get(node) + 1));
+      incomingCount.set(neighbor, incomingCount.get(neighbor) - 1);
+      if (incomingCount.get(neighbor) === 0) {
+        queue.push(neighbor);
+      }
+    });
+  }
+
+  // Cycles keep non-zero incoming; keep them in a deterministic fallback layer.
+  tableIds.forEach((id) => {
+    if (incomingCount.get(id) > 0) levels.set(id, 0);
+  });
+
+  const layers = [];
+  const maxLevel = Math.max(0, ...levels.values());
+  for (let i = 0; i <= maxLevel; i++) layers.push([]);
+  tables.forEach((table) => {
+    layers[levels.get(table.id)].push(table.id);
+  });
+  return layers;
+}
+
+function buildNeighbors(relationships) {
+  const neighbors = new Map();
+  relationships.forEach((rel) => {
+    if (!neighbors.has(rel.startTableId)) neighbors.set(rel.startTableId, new Set());
+    if (!neighbors.has(rel.endTableId)) neighbors.set(rel.endTableId, new Set());
+    neighbors.get(rel.startTableId).add(rel.endTableId);
+    neighbors.get(rel.endTableId).add(rel.startTableId);
+  });
+  return neighbors;
+}
+
+export function autoArrangeTables(tables, relationships, tableWidth) {
+  if (tables.length < 2) return tables;
+
+  const layers = buildLayering(tables, relationships);
+  const neighbors = buildNeighbors(relationships);
+  const order = new Map();
+
+  layers.forEach((layer) => {
+    layer.forEach((id, index) => order.set(id, index));
+  });
+
+  for (let pass = 0; pass < 8; pass++) {
+    layers.forEach((layer) => {
+      layer.sort((a, b) => {
+        const aNeighbors = [...(neighbors.get(a) || [])];
+        const bNeighbors = [...(neighbors.get(b) || [])];
+        const aScore =
+          aNeighbors.length === 0
+            ? order.get(a)
+            : aNeighbors.reduce((sum, id) => sum + (order.get(id) ?? 0), 0) /
+              aNeighbors.length;
+        const bScore =
+          bNeighbors.length === 0
+            ? order.get(b)
+            : bNeighbors.reduce((sum, id) => sum + (order.get(id) ?? 0), 0) /
+              bNeighbors.length;
+        return aScore - bScore;
+      });
+      layer.forEach((id, index) => order.set(id, index));
+    });
+  }
+
+  const colGap = 80;
+  const rowGap = 96;
+  const nextTables = tables.map((table) => ({ ...table }));
+  const byId = new Map(nextTables.map((table) => [table.id, table]));
+
+  layers.forEach((layer, layerIndex) => {
+    layer.forEach((id, rowIndex) => {
+      const table = byId.get(id);
+      if (!table) return;
+      table.x = layerIndex * (tableWidth + colGap);
+      table.y = rowIndex * rowGap;
+    });
+  });
+
+  // Local swaps to reduce estimated crossings after initial layering.
+  let improved = true;
+  while (improved) {
+    improved = false;
+    for (const layer of layers) {
+      for (let i = 0; i < layer.length - 1; i++) {
+        const a = byId.get(layer[i]);
+        const b = byId.get(layer[i + 1]);
+        if (!a || !b) continue;
+
+        const before = countRelationshipCrossings(nextTables, relationships, tableWidth);
+        const oldAY = a.y;
+        a.y = b.y;
+        b.y = oldAY;
+        const after = countRelationshipCrossings(nextTables, relationships, tableWidth);
+        if (after < before) {
+          improved = true;
+          [layer[i], layer[i + 1]] = [layer[i + 1], layer[i]];
+        } else {
+          const resetY = a.y;
+          a.y = b.y;
+          b.y = resetY;
+        }
+      }
+    }
+  }
+
+  return nextTables.map((table) => ({
+    ...table,
+    x: Math.round(table.x / gridSize) * gridSize,
+    y: Math.round(table.y / gridSize) * gridSize,
+  }));
+}
+
+export function createAutoArrangeUndoEntry(beforeTables, afterTables) {
+  const afterById = new Map(afterTables.map((table) => [table.id, table]));
+  return {
+    bulk: true,
+    action: Action.EDIT,
+    message: "Auto arrange tables",
+    elements: beforeTables
+      .filter((table) => afterById.has(table.id))
+      .map((table) => {
+        const next = afterById.get(table.id);
+        return {
+          id: table.id,
+          type: ObjectType.TABLE,
+          undo: { x: table.x, y: table.y },
+          redo: { x: next.x, y: next.y },
+        };
+      }),
+  };
+}


### PR DESCRIPTION
## Summary
This PR implements two new editor features:
1. Auto-arrange tables with a crossing-aware layout heuristic.
2. A live Stats box showing layout metrics.

## Features Implemented
- Added an **Auto arrange** button in the toolbar (`Ctrl+Alt+R`).
- Added a **Stats box** overlay on the canvas.

## Changes Made

### Auto-arrange
- New utility: `src/utils/autoArrange.js`
  - Builds a layered layout from relationships.
  - Reorders nodes with a barycenter heuristic.
  - Applies local swaps to reduce estimated edge crossings.
  - Snaps final table coordinates to grid.
  - Generates a bulk undo/redo history entry.

- Updated `src/components/EditorHeader/ControlPanel.jsx`
  - Added `autoArrange()` action.
  - Added toolbar button (shuffle icon).
  - Added hotkey: `Ctrl+Alt+R`.
  - Integrated with undo/redo and save-state behavior.

### Stats Box
- New component: `src/components/EditorCanvas/StatsBox.jsx`
  - Displays:
    - number of tables
    - number of relationships
    - max depth
    - estimated line crossings
    - connected components
    - isolated tables

- Updated `src/components/EditorCanvas/Canvas.jsx`
  - Integrated `StatsBox` as a canvas overlay.

## Testing Instructions
1. Run:
   - `npm run lint`
   - `npm run build`
2. Start app (`npm run dev`) and open a diagram with multiple tables/relationships.
3. Click **Auto arrange** (or press `Ctrl+Alt+R`).
4. Verify table positions are reorganized and crossings are reduced.
5. Verify undo/redo correctly reverts/reapplies the arrangement.
6. Verify the Stats box updates when tables/relationships change.

## Validation Performed
- `npm run lint` passed.
- `npm run build` passed.