### PR TITLE
add prime number type

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -32,6 +32,22 @@ const defaultTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (!intRegex.test(field.default)) {
+        return false;
+      }
+      const value = Number.parseInt(field.default, 10);
+      // Allow 1, 3, 5, 7, 9, 11, … (positive odd integers)
+      return value >= 1 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: true,
+  },
   SMALLINT: {
     type: "SMALLINT",
     color: intColor,


### PR DESCRIPTION
A new datatype definition was added to datatypes.js inside defaultTypesBase (available for the generic database).
Behavior: MYPRIMETYPE is treated as an integer-like type whose default value must be a positive odd integer (i.e., from the set 1, 3, 5, 7, 9, 11, …). It participates in the generic type system (DB.GENERIC) and appears anywhere types are derived from dbToTypes for that DB.