### PR TITLE
Add "Delete all fields" option to table context menu

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -34,7 +34,7 @@ export default function Table({
   const [hoveredField, setHoveredField] = useState(null);
   const { database } = useDiagram();
   const { layout } = useLayout();
-  const { deleteTable, deleteField, updateTable } = useDiagram();
+  const { deleteTable, deleteField, deleteAllFields, updateTable } = useDiagram();
   const { settings } = useSettings();
   const { t } = useTranslation();
   const {
@@ -242,6 +242,19 @@ export default function Table({
                             </div>
                           )}
                         </div>
+                        <Button
+                          icon={<IconDeleteStroked />}
+                          type="danger"
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={() => deleteAllFields(tableData.id)}
+                          disabled={
+                            layout.readOnly ||
+                            tableData.fields.length === 0
+                          }
+                        >
+                          {t("delete_all_fields")}
+                        </Button>
                         <Button
                           icon={<IconDeleteStroked />}
                           type="danger"

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -224,6 +224,15 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           updateTable(a.tid, {
             fields: table.fields.filter((e) => e.id !== a.fid),
           });
+        } else if (a.component === "fields_delete_all") {
+          setRelationships((prev) => {
+            let temp = [...prev];
+            a.data.relationship.forEach((r) => {
+              temp.splice(r.id, 0, r);
+            });
+            return temp;
+          });
+          updateTable(a.tid, { fields: a.data.fields });
         } else if (a.component === "index_add") {
           updateTable(a.tid, {
             indices: table.indices
@@ -400,6 +409,13 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
               },
             ],
           });
+        } else if (a.component === "fields_delete_all") {
+          setRelationships((prev) =>
+            prev.filter(
+              (e) => !(e.startTableId === a.tid || e.endTableId === a.tid),
+            ),
+          );
+          updateTable(a.tid, { fields: [] });
         } else if (a.component === "index_add") {
           updateTable(a.tid, {
             indices: [

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -173,6 +173,40 @@ export default function DiagramContextProvider({ children }) {
     });
   };
 
+  const deleteAllFields = (tid, addToHistory = true) => {
+    const table = tables.find((t) => t.id === tid);
+    if (!table || table.fields.length === 0) return;
+    if (addToHistory) {
+      const rels = relationships.filter(
+        (r) => r.startTableId === tid || r.endTableId === tid,
+      );
+      setUndoStack((prev) => [
+        ...prev,
+        {
+          action: Action.EDIT,
+          element: ObjectType.TABLE,
+          component: "fields_delete_all",
+          tid: tid,
+          data: {
+            fields: table.fields,
+            relationship: rels,
+          },
+          message: t("edit_table", {
+            tableName: table.name,
+            extra: "[delete all fields]",
+          }),
+        },
+      ]);
+      setRedoStack([]);
+    }
+    setRelationships((prev) =>
+      prev.filter(
+        (e) => !(e.startTableId === tid || e.endTableId === tid),
+      ),
+    );
+    updateTable(tid, { fields: [] });
+  };
+
   const addRelationship = (data, addToHistory = true) => {
     if (addToHistory) {
       setRelationships((prev) => {
@@ -237,6 +271,7 @@ export default function DiagramContextProvider({ children }) {
         updateTable,
         updateField,
         deleteField,
+        deleteAllFields,
         deleteTable,
         relationships,
         setRelationships,

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -127,6 +127,7 @@ const en = {
     this_will_appear_as_is: "*This will appear in the generated script as is.",
     comment: "Comment",
     add_field: "Add field",
+    delete_all_fields: "Delete all fields",
     values: "Values",
     size: "Size",
     precision: "Precision",


### PR DESCRIPTION
## Summary

- Adds a **"Delete all fields"** button to the table's `...` (more options) popover on the canvas
- Allows users to clear all fields from a table in a single action
- Full **undo/redo** support — undoing restores all fields and their relationships

## Changes

| File | What changed |
|---|---|
| `src/context/DiagramContext.jsx` | Added `deleteAllFields(tid)` function that saves fields + relationships to the undo stack, removes affected relationships, and clears the fields array. Exposed it via the context provider. |
| `src/components/EditorCanvas/Table.jsx` | Added a "Delete all fields" `<Button>` inside the `...` popover, placed above the existing "Delete" (table) button. Disabled when read-only or when the table has no fields. |
| `src/components/EditorHeader/ControlPanel.jsx` | Added `fields_delete_all` handling in both `undo()` and `redo()` — undo restores fields and relationships, redo re-clears them. |
| `src/i18n/locales/en.js` | Added `delete_all_fields: "Delete all fields"` translation key. |

## Testing Instructions

1. Run `npm install && npm run dev`
2. Open the editor and create a new diagram (any database type)
3. Add a table — it will have a default `id` field
4. Optionally add more fields via the side panel
5. Hover over the table on the canvas to reveal action buttons
6. Click the **"..."** button — the popover should now show **"Delete all fields"** above "Delete"
7. Click **"Delete all fields"** — all fields should be removed from the table
8. Press **Ctrl+Z** (undo) — all fields should be restored
9. Press **Ctrl+Y** (redo) — fields should be cleared again
10. Verify the button is **disabled** when the table has no fields
11. Verify the button is **disabled** in read-only mode

### Edge cases to check
- Table with relationships: deleting all fields should also remove connected relationships (and undo should restore them)
- Table with a single field
- Empty table (button should be disabled)

## Screenshots

_The new "Delete all fields" button appears in the table's `...` popover menu:_

```
┌──────────────────────┐
│ Comment: Not set      │
│ Indices: Not set      │
│                       │
│ [Delete all fields]   │  ← NEW
│ [Delete]              │
└──────────────────────┘
```


Made with [Cursor](https://cursor.com)