### PR TITLE
add new datatype MYPRIMETYPE, add option for each Table icon to delete all fields

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -34,7 +34,8 @@ export default function Table({
   const [hoveredField, setHoveredField] = useState(null);
   const { database } = useDiagram();
   const { layout } = useLayout();
-  const { deleteTable, deleteField, updateTable } = useDiagram();
+  const { deleteTable, deleteField, deleteAllFields, updateTable } =
+    useDiagram();
   const { settings } = useSettings();
   const { t } = useTranslation();
   const {
@@ -242,6 +243,15 @@ export default function Table({
                             </div>
                           )}
                         </div>
+                        <Button
+                          icon={<IconDeleteStroked />}
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={() => deleteAllFields(tableData.id)}
+                          disabled={layout.readOnly || tableData.fields.length === 0}
+                        >
+                          {t("clear")}
+                        </Button>
                         <Button
                           icon={<IconDeleteStroked />}
                           type="danger"

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -109,6 +109,7 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
     addTable,
     updateTable,
     deleteField,
+    deleteAllFields,
     deleteTable,
     updateField,
     setRelationships,
@@ -220,6 +221,9 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           const updatedFields = table.fields.slice();
           updatedFields.splice(a.data.index, 0, a.data.field);
           updateTable(a.tid, { fields: updatedFields });
+        } else if (a.component === "field_delete_all") {
+          setRelationships((prev) => [...prev, ...a.data.relationship]);
+          updateTable(a.tid, { fields: a.data.fields });
         } else if (a.component === "field_add") {
           updateTable(a.tid, {
             fields: table.fields.filter((e) => e.id !== a.fid),
@@ -382,6 +386,8 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           updateField(a.tid, a.fid, a.redo);
         } else if (a.component === "field_delete") {
           deleteField(a.data.field, a.tid, false);
+        } else if (a.component === "field_delete_all") {
+          deleteAllFields(a.tid, false);
         } else if (a.component === "field_add") {
           updateTable(a.tid, {
             fields: [

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -173,6 +173,52 @@ export default function DiagramContextProvider({ children }) {
     });
   };
 
+  const deleteAllFields = (tid, addToHistory = true) => {
+    const table = tables.find((t) => t.id === tid);
+    if (!table || table.fields.length === 0) return;
+
+    const rels = relationships.filter(
+      (r) =>
+        (r.startTableId === tid &&
+          table.fields.some((f) => f.id === r.startFieldId)) ||
+        (r.endTableId === tid && table.fields.some((f) => f.id === r.endFieldId)),
+    );
+
+    if (addToHistory) {
+      setUndoStack((prev) => [
+        ...prev,
+        {
+          action: Action.EDIT,
+          element: ObjectType.TABLE,
+          component: "field_delete_all",
+          tid,
+          data: {
+            fields: [...table.fields],
+            relationship: rels,
+          },
+          message: t("edit_table", {
+            tableName: table.name,
+            extra: "[delete all fields]",
+          }),
+        },
+      ]);
+      setRedoStack([]);
+    }
+
+    setRelationships((prev) =>
+      prev.filter(
+        (r) =>
+          !(
+            (r.startTableId === tid &&
+              table.fields.some((f) => f.id === r.startFieldId)) ||
+            (r.endTableId === tid &&
+              table.fields.some((f) => f.id === r.endFieldId))
+          ),
+      ),
+    );
+    updateTable(tid, { fields: [] });
+  };
+
   const addRelationship = (data, addToHistory = true) => {
     if (addToHistory) {
       setRelationships((prev) => {
@@ -237,6 +283,7 @@ export default function DiagramContextProvider({ children }) {
         updateTable,
         updateField,
         deleteField,
+        deleteAllFields,
         deleteTable,
         relationships,
         setRelationships,

--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -18,6 +18,23 @@ import { DB } from "./constants";
 const intRegex = /^-?\d*$/;
 const doubleRegex = /^-?\d*.?\d+$/;
 const binaryRegex = /^[01]+$/;
+const myPrimeTypeRegex = /^\d+$/;
+
+const myPrimeType = {
+  type: "MYPRIMETYPE",
+  color: intColor,
+  checkDefault: (field) => {
+    if (!myPrimeTypeRegex.test(field.default)) {
+      return false;
+    }
+    const value = Number.parseInt(field.default, 10);
+    return value >= 1 && value % 2 === 1;
+  },
+  hasCheck: true,
+  isSized: false,
+  hasPrecision: false,
+  canIncrement: false,
+};
 
 /* eslint-disable no-unused-vars */
 const defaultTypesBase = {
@@ -348,9 +365,12 @@ const defaultTypesBase = {
   },
 };
 
-export const defaultTypes = new Proxy(defaultTypesBase, {
+export const defaultTypes = new Proxy(
+  { ...defaultTypesBase, MYPRIMETYPE: myPrimeType },
+  {
   get: (target, prop) => (prop in target ? target[prop] : false),
-});
+  },
+);
 
 const mysqlTypesBase = {
   TINYINT: {
@@ -813,9 +833,12 @@ const mysqlTypesBase = {
   },
 };
 
-export const mysqlTypes = new Proxy(mysqlTypesBase, {
+export const mysqlTypes = new Proxy(
+  { ...mysqlTypesBase, MYPRIMETYPE: myPrimeType },
+  {
   get: (target, prop) => (prop in target ? target[prop] : false),
-});
+  },
+);
 
 const postgresTypesBase = {
   SMALLINT: {
@@ -1402,9 +1425,12 @@ const postgresTypesBase = {
   },
 };
 
-export const postgresTypes = new Proxy(postgresTypesBase, {
+export const postgresTypes = new Proxy(
+  { ...postgresTypesBase, MYPRIMETYPE: myPrimeType },
+  {
   get: (target, prop) => (prop in target ? target[prop] : false),
-});
+  },
+);
 
 const sqliteTypesBase = {
   INTEGER: {
@@ -1551,9 +1577,12 @@ const sqliteTypesBase = {
   },
 };
 
-export const sqliteTypes = new Proxy(sqliteTypesBase, {
+export const sqliteTypes = new Proxy(
+  { ...sqliteTypesBase, MYPRIMETYPE: myPrimeType },
+  {
   get: (target, prop) => (prop in target ? target[prop] : false),
-});
+  },
+);
 
 const mssqlTypesBase = {
   TINYINT: {
@@ -1972,9 +2001,12 @@ const mssqlTypesBase = {
   },
 };
 
-export const mssqlTypes = new Proxy(mssqlTypesBase, {
+export const mssqlTypes = new Proxy(
+  { ...mssqlTypesBase, MYPRIMETYPE: myPrimeType },
+  {
   get: (target, prop) => (prop in target ? target[prop] : false),
-});
+  },
+);
 
 const oraclesqlTypesBase = {
   INTEGER: {
@@ -2203,9 +2235,12 @@ const oraclesqlTypesBase = {
   },
 };
 
-export const oraclesqlTypes = new Proxy(oraclesqlTypesBase, {
+export const oraclesqlTypes = new Proxy(
+  { ...oraclesqlTypesBase, MYPRIMETYPE: myPrimeType },
+  {
   get: (target, prop) => (prop in target ? target[prop] : false),
-});
+  },
+);
 
 export const mariadbTypesBase = {
   UUID: {


### PR DESCRIPTION
Add a new datatype MYPRIMETYPE that supports a fixed set of prime numbers: 1, 3, 5, 7, 9, 11, …
Add an option for each Table icon to delete all fields
- In the default view, the “...” icon shows additional options.
