### PR TITLE
add options 1 and 2

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -243,6 +243,24 @@ export default function Table({
                           )}
                         </div>
                         <Button
+                          icon={<IconMinus />}
+                          type="danger"
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={() => {
+                            if (layout.readOnly) return;
+                            const fieldsToDelete = tableData.fields.filter(
+                              (field) => field.name !== "id",
+                            );
+                            fieldsToDelete.forEach((field) => {
+                              deleteField(field, tableData.id);
+                            });
+                          }}
+                          disabled={layout.readOnly}
+                        >
+                          Delete all fields
+                        </Button>
+                        <Button
                           icon={<IconDeleteStroked />}
                           type="danger"
                           block

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -128,37 +128,54 @@ export default function DiagramContextProvider({ children }) {
   };
 
   const deleteField = (field, tid, addToHistory = true) => {
-    const { fields, name } = tables.find((t) => t.id === tid);
-    if (addToHistory) {
-      const rels = relationships.reduce((acc, r) => {
-        if (
-          (r.startTableId === tid && r.startFieldId === field.id) ||
-          (r.endTableId === tid && r.endFieldId === field.id)
-        ) {
-          acc.push(r);
-        }
-        return acc;
-      }, []);
-      setUndoStack((prev) => [
-        ...prev,
-        {
-          action: Action.EDIT,
-          element: ObjectType.TABLE,
-          component: "field_delete",
-          tid: tid,
-          data: {
-            field: field,
-            index: fields.findIndex((f) => f.id === field.id),
-            relationship: rels,
+    setTables((prevTables) => {
+      const tableIndex = prevTables.findIndex((t) => t.id === tid);
+      if (tableIndex === -1) return prevTables;
+
+      const table = prevTables[tableIndex];
+      const { fields, name } = table;
+
+      if (addToHistory) {
+        const rels = relationships.reduce((acc, r) => {
+          if (
+            (r.startTableId === tid && r.startFieldId === field.id) ||
+            (r.endTableId === tid && r.endFieldId === field.id)
+          ) {
+            acc.push(r);
+          }
+          return acc;
+        }, []);
+        setUndoStack((prev) => [
+          ...prev,
+          {
+            action: Action.EDIT,
+            element: ObjectType.TABLE,
+            component: "field_delete",
+            tid: tid,
+            data: {
+              field: field,
+              index: fields.findIndex((f) => f.id === field.id),
+              relationship: rels,
+            },
+            message: t("edit_table", {
+              tableName: name,
+              extra: "[delete field]",
+            }),
           },
-          message: t("edit_table", {
-            tableName: name,
-            extra: "[delete field]",
-          }),
-        },
-      ]);
-      setRedoStack([]);
-    }
+        ]);
+        setRedoStack([]);
+      }
+
+      const updatedTable = {
+        ...table,
+        fields: fields.filter((e) => e.id !== field.id),
+      };
+
+      const newTables = [...prevTables];
+      newTables[tableIndex] = updatedTable;
+      return newTables;
+    });
+
     setRelationships((prev) =>
       prev.filter(
         (e) =>
@@ -168,9 +185,6 @@ export default function DiagramContextProvider({ children }) {
           ),
       ),
     );
-    updateTable(tid, {
-      fields: fields.filter((e) => e.id !== field.id),
-    });
   };
 
   const addRelationship = (data, addToHistory = true) => {

--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -18,6 +18,7 @@ import { DB } from "./constants";
 const intRegex = /^-?\d*$/;
 const doubleRegex = /^-?\d*.?\d+$/;
 const binaryRegex = /^[01]+$/;
+const myPrimeRegex = /^(?:[13579]|[1-9]\d*[13579])$/;
 
 /* eslint-disable no-unused-vars */
 const defaultTypesBase = {
@@ -346,6 +347,17 @@ const defaultTypesBase = {
     hasPrecision: false,
     noDefault: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      // Allow only positive odd integers (1, 3, 5, 7, 9, 11, ...)
+      return myPrimeRegex.test(field.default);
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+  },
 };
 
 export const defaultTypes = new Proxy(defaultTypesBase, {
@@ -412,6 +424,17 @@ const mysqlTypesBase = {
     hasPrecision: false,
     canIncrement: true,
     signed: true,
+  },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      // Allow only positive odd integers (1, 3, 5, 7, 9, 11, ...)
+      return myPrimeRegex.test(field.default);
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
   },
   DECIMAL: {
     type: "DECIMAL",


### PR DESCRIPTION
- Table-level “Delete all fields” action: Added a new option in the table header ... popover that deletes all non-id fields from a table in one click, reusing the existing deleteField logic, fixing state handling so multiple deletions work correctly, and respecting read-only mode.

- Custom MYPRIMETYPE datatype: Introduced a new MYPRIMETYPE scalar type (generic + MySQL/MariaDB) with validation that its default value is a positive odd integer (1, 3, 5, 7, 9, 11, …), and wired it into the field type dropdown so it can be selected like any other built-in type.