### PR TITLE
Add a new datatype MYPRIMETYPE

### DIFF
--- a/src/data/datatypes.js
+++ b/src/data/datatypes.js
@@ -32,6 +32,20 @@ const defaultTypesBase = {
     hasPrecision: false,
     canIncrement: true,
   },
+  MYPRIMETYPE: {
+    type: "MYPRIMETYPE",
+    color: intColor,
+    checkDefault: (field) => {
+      if (field.default === "") return true;
+      if (!intRegex.test(field.default)) return false;
+      const value = Number.parseInt(field.default, 10);
+      return Number.isInteger(value) && value > 0 && value % 2 === 1;
+    },
+    hasCheck: true,
+    isSized: false,
+    hasPrecision: false,
+    canIncrement: false,
+  },
   SMALLINT: {
     type: "SMALLINT",
     color: intColor,


### PR DESCRIPTION
### New Data Type `MYPRIMETYPE`

A new data type definition has been added to the general type collection `defaultTypesBase` in `src/data/datatypes.js`:

- **Name**: `MYPRIMETYPE`
- **Color category**: Uses the integer type color (`intColor`), so it appears similar to integer types in the UI.
- **Default value validation rules (core logic)**:
  - Allows an empty default value (i.e., considered valid when no default value is provided).
  - When the default value is not empty:
    - It must be an integer (checked using the existing `intRegex`).
    - The parsed value must be a **positive integer** and **odd**, meaning supported values look like `1, 3, 5, 7, 9, 11, …`.
- **Other attributes**:
  - `hasCheck: true`: Allows an additional custom `CHECK` to be specified in the field details.
  - `isSized: false`: Does not support the `SIZE` parameter.
  - `hasPrecision: false`: Does not support precision parameters.
  - `canIncrement: false`: Does not support auto-increment.

Now, when editing table fields, `MYPRIMETYPE` will appear in the type dropdown menu. If the default value is not a positive odd number such as `1, 3, 5, 7, 9, 11, …`, it will be marked in **“Issues”** as a mismatch between the default value and the type.