### PR TITLE
Added feature of option for each table icon AND generated sample data…

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -34,7 +34,8 @@ export default function Table({
   const [hoveredField, setHoveredField] = useState(null);
   const { database } = useDiagram();
   const { layout } = useLayout();
-  const { deleteTable, deleteField, updateTable } = useDiagram();
+  const { deleteTable, deleteField, deleteAllFields, updateTable } =
+    useDiagram();
   const { settings } = useSettings();
   const { t } = useTranslation();
   const {
@@ -242,6 +243,18 @@ export default function Table({
                             </div>
                           )}
                         </div>
+                        <Button
+                          icon={<IconMinus />}
+                          type="warning"
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={() => deleteAllFields(tableData.id)}
+                          disabled={
+                            layout.readOnly || tableData.fields.length === 0
+                          }
+                        >
+                          {t("delete_all_fields")}
+                        </Button>
                         <Button
                           icon={<IconDeleteStroked />}
                           type="danger"

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -80,6 +80,7 @@ import { IdContext } from "../Workspace";
 import { socials } from "../../data/socials";
 import { toDBML } from "../../utils/exportAs/dbml";
 import { exportSavedData } from "../../utils/exportSavedData";
+import { generateSampleData } from "../../utils/generateSampleData";
 import { nanoid } from "nanoid";
 import { getTableHeight } from "../../utils/utils";
 import { deleteFromCache, STORAGE_KEY } from "../../utils/cache";
@@ -109,6 +110,7 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
     addTable,
     updateTable,
     deleteField,
+    deleteAllFields,
     deleteTable,
     updateField,
     setRelationships,
@@ -220,6 +222,9 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           const updatedFields = table.fields.slice();
           updatedFields.splice(a.data.index, 0, a.data.field);
           updateTable(a.tid, { fields: updatedFields });
+        } else if (a.component === "field_delete_all") {
+          setRelationships((prev) => [...prev, ...a.data.relationship]);
+          updateTable(a.tid, { fields: a.data.fields });
         } else if (a.component === "field_add") {
           updateTable(a.tid, {
             fields: table.fields.filter((e) => e.id !== a.fid),
@@ -382,6 +387,8 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
           updateField(a.tid, a.fid, a.redo);
         } else if (a.component === "field_delete") {
           deleteField(a.data.field, a.tid, false);
+        } else if (a.component === "field_delete_all") {
+          deleteAllFields(a.tid, false);
         } else if (a.component === "field_add") {
           updateTable(a.tid, {
             fields: [
@@ -1067,6 +1074,25 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
       },
       export_as: {
         children: [
+          {
+            name: t("sample_data"),
+            function: () => {
+              setModal(MODAL.CODE);
+              const src = generateSampleData(
+                {
+                  tables: tables,
+                  references: relationships,
+                  database: database,
+                },
+                { rowCount: 5 },
+              );
+              setExportData((prev) => ({
+                ...prev,
+                data: src || t("no_tables_to_generate_sample"),
+                extension: "sql",
+              }));
+            },
+          },
           {
             name: "PNG",
             function: () => {

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -173,6 +173,40 @@ export default function DiagramContextProvider({ children }) {
     });
   };
 
+  const deleteAllFields = (tid, addToHistory = true) => {
+    const table = tables.find((t) => t.id === tid);
+    if (!table || table.fields.length === 0) return;
+    const { fields, name } = table;
+    if (addToHistory) {
+      const rels = relationships.filter(
+        (r) => r.startTableId === tid || r.endTableId === tid,
+      );
+      setUndoStack((prev) => [
+        ...prev,
+        {
+          action: Action.EDIT,
+          element: ObjectType.TABLE,
+          component: "field_delete_all",
+          tid: tid,
+          data: {
+            fields: [...fields],
+            relationship: rels,
+          },
+          message: t("edit_table", {
+            tableName: name,
+            extra: "[delete all fields]",
+          }),
+        },
+      ]);
+      setRedoStack([]);
+      Toast.success(t("all_fields_deleted"));
+    }
+    setRelationships((prev) =>
+      prev.filter((r) => r.startTableId !== tid && r.endTableId !== tid),
+    );
+    updateTable(tid, { fields: [] });
+  };
+
   const addRelationship = (data, addToHistory = true) => {
     if (addToHistory) {
       setRelationships((prev) => {
@@ -237,6 +271,7 @@ export default function DiagramContextProvider({ children }) {
         updateTable,
         updateField,
         deleteField,
+        deleteAllFields,
         deleteTable,
         relationships,
         setRelationships,

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -279,6 +279,11 @@ const en = {
     insert_sql: "Insert SQL",
     upload_file: "Upload file",
     show_comments: "Show comments",
+    delete_all_fields: "Delete all fields",
+    all_fields_deleted: "All fields deleted",
+    sample_data: "Sample data",
+    no_tables_to_generate_sample:
+      "No tables with fields to generate sample data from.",
   },
 };
 

--- a/src/utils/generateSampleData.js
+++ b/src/utils/generateSampleData.js
@@ -1,0 +1,189 @@
+import { DB } from "../data/constants";
+import { dbToTypes } from "../data/datatypes";
+
+const SAMPLE_ROW_COUNT = 5;
+
+/**
+ * Generate a sample value for a field based on its type and row index
+ */
+function generateSampleValue(field, rowIndex, database) {
+  const typeInfo = dbToTypes[database]?.[field.type] || dbToTypes[DB.GENERIC]?.[field.type];
+
+  if (field.default && field.default !== "") {
+    return field.default;
+  }
+
+  if (field.increment && field.primary) {
+    return rowIndex + 1;
+  }
+
+  const type = (field.type || "").toUpperCase();
+
+  // Integer types
+  if (
+    [
+      "INT",
+      "INTEGER",
+      "SMALLINT",
+      "BIGINT",
+      "TINYINT",
+      "MEDIUMINT",
+      "SERIAL",
+      "SMALLSERIAL",
+      "BIGSERIAL",
+      "NUMBER",
+      "LONG",
+    ].includes(type)
+  ) {
+    return rowIndex + 1;
+  }
+
+  // Decimal/float types
+  if (
+    ["DECIMAL", "NUMERIC", "FLOAT", "DOUBLE", "REAL", "MONEY", "SMALLMONEY"].includes(type)
+  ) {
+    return (rowIndex + 1) * 10.5;
+  }
+
+  // Boolean
+  if (["BOOLEAN", "BIT"].includes(type)) {
+    return rowIndex % 2 === 0 ? 1 : 0;
+  }
+
+  // Date types
+  if (type === "DATE") {
+    return `'${2024}-01-${String(rowIndex + 1).padStart(2, "0")}'`;
+  }
+  if (["DATETIME", "TIMESTAMP", "SMALLDATETIME", "DATETIME2", "DATETIMEOFFSET"].includes(type)) {
+    return `'${2024}-01-${String(rowIndex + 1).padStart(2, "0")} 10:00:00'`;
+  }
+  if (["TIME", "TIMETZ"].includes(type)) {
+    return `'${String(10 + rowIndex).padStart(2, "0")}:00:00'`;
+  }
+  if (type === "YEAR") {
+    return 2024;
+  }
+
+  // UUID
+  if (type === "UUID" || type === "UNIQUEIDENTIFIER") {
+    const hex = (rowIndex + 1).toString(16).padStart(12, "0");
+    return `'${"00000000-0000-0000-0000-".padEnd(36, "0").slice(0, -12) + hex}'`;
+  }
+
+  // ENUM
+  if (type === "ENUM" && field.values?.length > 0) {
+    const val = field.values[rowIndex % field.values.length];
+    return `'${String(val).replace(/'/g, "''")}'`;
+  }
+
+  // SET
+  if (type === "SET" && field.values?.length > 0) {
+    const val = field.values[0];
+    return `'${String(val).replace(/'/g, "''")}'`;
+  }
+
+  // String types (default)
+  const stringSamples = [
+    "Sample",
+    "Example",
+    "Test",
+    "Demo",
+    "Sample data",
+  ];
+  const str = stringSamples[rowIndex % stringSamples.length];
+  return `'${str} ${rowIndex + 1}'`;
+}
+
+/**
+ * Escape value for SQL - handles null and already-quoted values
+ */
+function formatValueForSQL(value, field, database) {
+  if (value === null || value === undefined) {
+    return "NULL";
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "string" && value.startsWith("'") && value.endsWith("'")) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/**
+ * Generate sample INSERT statements for all tables in a diagram
+ */
+export function generateSampleData(diagram, options = {}) {
+  const { rowCount = SAMPLE_ROW_COUNT, database } = options;
+  const db = database || diagram.database || DB.MYSQL;
+  const references = diagram.references || diagram.relationships || [];
+
+  const lines = [];
+  const tableOrder = getTableInsertOrder(diagram.tables, references);
+
+  for (const table of tableOrder) {
+    if (!table.fields || table.fields.length === 0) continue;
+
+    const columns = table.fields
+      .filter((f) => !f.increment || !f.primary)
+      .map((f) => `\`${f.name}\``);
+
+    if (columns.length === 0) continue;
+
+    for (let i = 0; i < rowCount; i++) {
+      const values = table.fields
+        .filter((f) => !f.increment || !f.primary)
+        .map((f) => {
+          const val = generateSampleValue(f, i, db);
+          return formatValueForSQL(val, f, db);
+        });
+
+      lines.push(
+        `INSERT INTO \`${table.name}\` (${columns.join(", ")}) VALUES (${values.join(", ")});`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+/**
+ * Determine table order for insertion (parents before children for FK integrity)
+ */
+function getTableInsertOrder(tables, references) {
+  if (!references || references.length === 0) {
+    return [...tables];
+  }
+
+  const tableIds = new Set(tables.map((t) => t.id));
+  const childToParent = new Map();
+  for (const ref of references) {
+    childToParent.set(ref.startTableId, ref.endTableId);
+  }
+
+  const ordered = [];
+  const visited = new Set();
+
+  function visit(tableId) {
+    if (visited.has(tableId)) return;
+    const parentId = childToParent.get(tableId);
+    if (parentId && tableIds.has(parentId)) {
+      visit(parentId);
+    }
+    const table = tables.find((t) => t.id === tableId);
+    if (table) {
+      ordered.push(table);
+      visited.add(tableId);
+    }
+  }
+
+  for (const table of tables) {
+    visit(table.id);
+  }
+
+  return ordered;
+}


### PR DESCRIPTION
Feature Summary
This PR adds two features:

Delete All Fields: Each table’s "..." menu now includes a "Delete all fields" option that removes all columns from the table and any relationships involving it. The action is undoable.

Generate Sample Data: A new "Sample data" option under File → Export as generates SQL INSERT statements from the diagram’s tables, with sample values based on column types (integers, strings, dates, booleans, enums, etc.).

Changes Made
DiagramContext.jsx: Implemented deleteAllFields with undo history.
Table.jsx: Added "Delete all fields" button to the table popover.
ControlPanel.jsx: Wired undo/redo for delete-all-fields and added the "Sample data" export option.
generateSampleData.js: New utility for generating sample SQL from table schemas.
en.js: Added translation keys for the new UI strings.
Testing Instructions
Delete All Fields:

Create a diagram with at least one table that has multiple fields.
Hover over the table header and click the "..." (more options) icon.
Click "Delete all fields" and confirm all fields are removed.
Use Undo (Ctrl+Z) to restore the fields.
Use Redo (Ctrl+Y) to remove them again.
Generate Sample Data:

Create a diagram with one or more tables.
Go to File → Export as → Sample data.
Confirm the modal shows generated SQL INSERT statements.
Copy or download the SQL and verify it matches the table structure.