### PR TITLE
Add delete-all-fields option to table menu

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -65,6 +65,14 @@ export default function Table({
     );
   }, [selectedElement, tableData, bulkSelectedElements]);
 
+  const deleteAllFields = () => {
+    if (layout.readOnly) return;
+
+    tableData.fields.forEach((field) => {
+      deleteField(field, tableData.id);
+    });
+  };
+
   const lockUnlockTable = (e) => {
     const locking = !tableData.locked;
     updateTable(tableData.id, { locked: locking });
@@ -242,6 +250,16 @@ export default function Table({
                             </div>
                           )}
                         </div>
+                        <Button
+                          icon={<IconDeleteStroked />}
+                          type="danger"
+                          block
+                          style={{ marginTop: "8px" }}
+                          onClick={deleteAllFields}
+                          disabled={layout.readOnly}
+                        >
+                          Delete all fields
+                        </Button>
                         <Button
                           icon={<IconDeleteStroked />}
                           type="danger"


### PR DESCRIPTION
Summary
This PR adds a new “Delete all fields” option to each table’s header menu (the ... icon). It lets users quickly clear all columns from a table while keeping the table itself.

Changes

Added a deleteAllFields handler in Table.jsx that iterates over tableData.fields and calls the existing deleteField function for each field.
Updated the table header popover to include a “Delete all fields” button, respecting read-only mode.
Kept existing table delete behavior unchanged (separate “Delete” button for removing the whole table).
Testing

Ran npm run lint.
Ran npm run build.
Manual testing:
Created a new diagram and added a table.
Added several fields to the table.
Opened the table’s ... menu and clicked “Delete all fields”.
Verified that all fields were removed and the table remained.
Verified the button is disabled when the diagram is read-only.