### PR TITLE
Increase relationship line thickness on hover

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -227,7 +227,8 @@
 
 .group:hover .relationship-path {
   stroke: #0084d1;
-  stroke-width: 2;
+  stroke-width: 6;
   stroke-dasharray: 12 8;
   animation: dash-right 1s linear infinite;
+  
 }


### PR DESCRIPTION
When a user clicks/hovers on a relationship line in the editor canvas, it highlights with a blue dashed animation. This change increases the stroke-width of the highlighted line from 2 to 6 in the .group:hover .relationship-path CSS rule, making the selected relationship line noticeably thicker and easier to see.

Prior to the change it was very difficult to see where the selected relationship went when it was underneath other relationships.

<img width="293" height="278" alt="image" src="https://github.com/user-attachments/assets/5c3f368f-5a75-4e95-9d9b-96e38939df65" />
