### PR TITLE
Fix: implement missing onOk handler to download migration zip

### DIFF
--- a/src/components/EditorHeader/SideSheet/Migration.jsx
+++ b/src/components/EditorHeader/SideSheet/Migration.jsx
@@ -11,7 +11,6 @@ import CodeEditor from "../../CodeEditor";
 import { generateMigrationSQL } from "../../../utils/migrations/diffToSQL";
 import * as JSZip from "jszip";
 import { saveAs } from "file-saver";
-import { set } from "lodash";
 
 export default function Migration({
   gistId,
@@ -80,21 +79,21 @@ export default function Migration({
     }
   }, [gistId, selectedVersion, versionToCompareTo]);
 
- const handleConfirm = () => {
-  if (!migrationSQL?.up) return;
+  const handleConfirm = () => {
+    if (!migrationSQL?.up) return;
 
-  const JSZipConstructor = JSZip.default || JSZip;
-  const zip = new JSZipConstructor();
-  
-  zip.file(`${filename}.up.sql`, migrationSQL.up);
-  zip.file(`${filename}.down.sql`, migrationSQL.down);
+    const JSZipConstructor = JSZip.default || JSZip;
+    const zip = new JSZipConstructor();
 
-  zip.generateAsync({ type: "blob" }).then(function (content) {
-    saveAs(content, `${filename}.zip`);
-  });
+    zip.file(`${filename}.up.sql`, migrationSQL.up);
+    zip.file(`${filename}.down.sql`, migrationSQL.down);
 
-  setSelectedVersion(null);
-};
+    zip.generateAsync({ type: "blob" }).then(function (content) {
+      saveAs(content, `${filename}.zip`);
+    });
+
+    setSelectedVersion(null);
+  };
 
   useEffect(() => {
     if (versionToCompareTo === "") {


### PR DESCRIPTION
### Description
Resolves #956

This PR fixes the bug where the "Confirm" button on the Migrations (Beta) modal was unresponsive, preventing users from downloading their generated SQL migration scripts.

### Solution
The issue occurred because the Semi UI `<Modal>` component was missing the `onOk` event handler. 

To fix this:
- Imported `JSZip` and `file-saver` in `Migration.jsx`.
- Implemented a `handleConfirm` function that packages the `up.sql` and `down.sql` scripts into a `.zip` blob and triggers the download.
- Used `JSZip.default || JSZip` instantiation to ensure compatibility with Vite's module bundling and prevent `TypeError: JSZip is not a constructor`.
- Attached the `handleConfirm` function to the `onOk` prop of the Modal.

Evidence: 
<img width="960" height="850" alt="Captura de pantalla 2026-03-25 a la(s) 11 56 13 a m" src="https://github.com/user-attachments/assets/24863228-97f3-49db-b83f-56e9d9012a14" />
