### PR TITLE
fix: correct typo 'realtionship' in meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Online database entity-realtionship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
+      content="Online database entity-relationship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
     />
 
     <meta name="robots" content="index,follow,max-image-preview:large" />
@@ -21,7 +21,7 @@
     />
     <meta
       property="og:description"
-      content="Online database entity-realtionship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
+      content="Online database entity-relationship diagram editor, data modeler, and SQL generator. Design, visualize, and export scripts without an account and completely free of charge."
     />
     <meta property="og:image" content="https://drawdb.app/hero_ss.png" />
 


### PR DESCRIPTION
## Summary

- Fixes a typo in the `<meta name="description">` and `<meta property="og:description">` tags in `index.html`: `realtionship` → `relationship`

## Test plan

- [ ] Verify the meta description in browser dev tools or page source shows the correct spelling

Fixes #778