### PR TITLE
fix: offset new elements to prevent overlap at same position

### DIFF
--- a/src/context/AreasContext.jsx
+++ b/src/context/AreasContext.jsx
@@ -23,19 +23,27 @@ export default function AreasContextProvider({ children }) {
     } else {
       const width = 200;
       const height = 200;
-      setAreas((prev) => [
-        ...prev,
-        {
-          id: prev.length,
-          name: `area_${prev.length}`,
-          x: transform.pan.x - width / 2,
-          y: transform.pan.y - height / 2,
-          width,
-          height,
-          color: defaultBlue,
-          locked: false,
-        },
-      ]);
+      setAreas((prev) => {
+        let x = transform.pan.x - width / 2;
+        let y = transform.pan.y - height / 2;
+        while (prev.some((a) => a.x === x && a.y === y)) {
+          x += 20;
+          y += 20;
+        }
+        return [
+          ...prev,
+          {
+            id: prev.length,
+            name: `area_${prev.length}`,
+            x,
+            y,
+            width,
+            height,
+            color: defaultBlue,
+            locked: false,
+          },
+        ];
+      });
     }
     if (addToHistory) {
       setUndoStack((prev) => [

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -18,11 +18,17 @@ export default function DiagramContextProvider({ children }) {
 
   const addTable = (data, addToHistory = true) => {
     const id = nanoid();
+    let x = transform.pan.x;
+    let y = transform.pan.y;
+    while (tables.some((t) => t.x === x && t.y === y)) {
+      x += 20;
+      y += 20;
+    }
     const newTable = {
       id,
       name: `table_${id}`,
-      x: transform.pan.x,
-      y: transform.pan.y,
+      x,
+      y,
       locked: false,
       fields: [
         {

--- a/src/context/NotesContext.jsx
+++ b/src/context/NotesContext.jsx
@@ -27,20 +27,28 @@ export default function NotesContextProvider({ children }) {
       });
     } else {
       const height = 88;
-      setNotes((prev) => [
-        ...prev,
-        {
-          id: prev.length,
-          x: transform.pan.x,
-          y: transform.pan.y - height / 2,
-          title: `note_${prev.length}`,
-          content: "",
-          locked: false,
-          color: defaultNoteTheme,
-          height,
-          width: noteWidth,
-        },
-      ]);
+      setNotes((prev) => {
+        let x = transform.pan.x;
+        let y = transform.pan.y - height / 2;
+        while (prev.some((n) => n.x === x && n.y === y)) {
+          x += 20;
+          y += 20;
+        }
+        return [
+          ...prev,
+          {
+            id: prev.length,
+            x,
+            y,
+            title: `note_${prev.length}`,
+            content: "",
+            locked: false,
+            color: defaultNoteTheme,
+            height,
+            width: noteWidth,
+          },
+        ];
+      });
     }
     if (addToHistory) {
       setUndoStack((prev) => [


### PR DESCRIPTION
## Summary

- Tables, notes, and areas were all placed at `(transform.pan.x, transform.pan.y)` when created, causing every new element to stack on top of the previous ones
- Added a position check in `addTable` (DiagramContext), `addNote` (NotesContext), and `addArea` (AreasContext): if an existing element of the same type already occupies the target position, increment both x and y by 20px until a free spot is found
- This mirrors the existing `+20px` offset pattern already used by the `duplicate` function in `ControlPanel.jsx`

## Test plan

- [ ] Add multiple tables without moving the canvas — each should appear offset from the previous one
- [ ] Same test for notes and areas
- [ ] Undo/redo behavior should still work correctly
- [ ] Elements created from history restore (with `data` argument) are unaffected

Fixes #736