### PR TITLE
fix: align Markdown export table columns with consistent padding

### DIFF
--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -2,6 +2,22 @@ import { dbToTypes } from "../../data/datatypes";
 import { jsonToMermaid } from "./mermaid";
 import { databases } from "../../data/databases";
 
+function formatMarkdownTable(headers, rows) {
+  const allRows = [headers, ...rows];
+  const colWidths = headers.map((_, colIndex) =>
+    Math.max(...allRows.map((row) => (row[colIndex] ?? "").length)),
+  );
+
+  const pad = (cell, width) => (cell ?? "").padEnd(width);
+  const separator = colWidths.map((w) => "-".repeat(w)).join(" | ");
+  const headerRow = headers.map((h, i) => pad(h, colWidths[i])).join(" | ");
+  const dataRows = rows
+    .map((row) => row.map((cell, i) => pad(cell, colWidths[i])).join(" | "))
+    .join("\n");
+
+  return `| ${headerRow} |\n| ${separator} |\n| ${dataRows} |`;
+}
+
 export function jsonToDocumentation(obj) {
   const documentationSummary = obj.tables
     .map((table) => {
@@ -12,43 +28,59 @@ export function jsonToDocumentation(obj) {
   const documentationEntities = obj.tables
     .map((table) => {
       let enums = "";
-      let indexes =
-        table.indices.length > 0
-          ? table.indices
-              .map((index) => {
-                return `| ${index.name} | ${index.unique ? "✅" : ""} | ${index.fields.join(", ")} |`;
-              })
-              .join("\n")
-          : "";
-      const fields = table.fields
-        .map((field) => {
-          const fieldType =
-            field.type +
-            ((dbToTypes[obj.database][field.type].isSized ||
-              dbToTypes[obj.database][field.type].hasPrecision) &&
-            field.size &&
-            field.size !== ""
-              ? "(" + field.size + ")"
-              : "");
-          enums +=
-            field.type === "ENUM" && field.values && field.values.length > 0
-              ? `##### ${field.name}\n\n${field.values.map((index) => `- ${index}`).join("\n")}\n`
-              : "";
-          return (
-            `| **${field.name}** | ${fieldType} | ${field.primary ? "🔑 PK, " : ""}` +
-            `${field.notNull ? "not null" : "null"}${field.unique ? ", unique" : ""}${field.increment ? ", autoincrement" : ""}` +
-            `${field.default ? `, default: ${field.default}` : ""} | ` +
-            `${relationshipByField(table.id, obj.relationships, field.id)}` +
-            ` |${field.comment ? field.comment : ""} |`
-          );
-        })
-        .join("\n");
+
+      const fieldRows = table.fields.map((field) => {
+        const fieldType =
+          field.type +
+          ((dbToTypes[obj.database][field.type].isSized ||
+            dbToTypes[obj.database][field.type].hasPrecision) &&
+          field.size &&
+          field.size !== ""
+            ? "(" + field.size + ")"
+            : "");
+
+        enums +=
+          field.type === "ENUM" && field.values && field.values.length > 0
+            ? `##### ${field.name}\n\n${field.values.map((v) => `- ${v}`).join("\n")}\n`
+            : "";
+
+        const settings =
+          `${field.primary ? "🔑 PK, " : ""}` +
+          `${field.notNull ? "not null" : "null"}` +
+          `${field.unique ? ", unique" : ""}` +
+          `${field.increment ? ", autoincrement" : ""}` +
+          `${field.default ? `, default: ${field.default}` : ""}`;
+
+        const references = relationshipByField(
+          table.id,
+          obj.relationships,
+          field.id,
+        ).join(", ");
+
+        return [`**${field.name}**`, fieldType, settings, references, field.comment ?? ""];
+      });
+
+      const fieldsTable = formatMarkdownTable(
+        ["Name", "Type", "Settings", "References", "Note"],
+        fieldRows,
+      );
+
+      let indexesSection = "";
+      if (table.indices.length > 0) {
+        const indexRows = table.indices.map((index) => [
+          index.name,
+          index.unique ? "✅" : "",
+          index.fields.join(", "),
+        ]);
+        indexesSection =
+          "\n#### Indexes\n" +
+          formatMarkdownTable(["Name", "Unique", "Fields"], indexRows);
+      }
+
       return (
         `### ${table.name}\n${table.comment ? table.comment : ""}\n` +
-        `| Name        | Type          | Settings                      | References                    | Note                           |\n` +
-        `|-------------|---------------|-------------------------------|-------------------------------|--------------------------------|\n` +
-        `${fields} \n${enums.length > 0 ? "\n#### Enums\n" + enums : ""}\n` +
-        `${indexes.length > 0 ? "\n#### Indexes\n| Name | Unique | Fields |\n|------|--------|--------|\n" + indexes : ""}`
+        `${fieldsTable} \n${enums.length > 0 ? "\n#### Enums\n" + enums : ""}\n` +
+        indexesSection
       );
     })
     .join("\n");
@@ -75,11 +107,8 @@ export function jsonToDocumentation(obj) {
     databases[obj.database].hasTypes && obj.types.length > 0
       ? obj.types
           .map((type) => {
-            return (
-              `| Name        | fields        | Note                           |\n` +
-              `|-------------|---------------|--------------------------------|\n` +
-              `| ${type.name} | ${type.fields.map((field) => field.name).join(", ")} | ${type.comment ? type.comment : ""} |`
-            );
+            const rows = [[type.name, type.fields.map((f) => f.name).join(", "), type.comment ?? ""]];
+            return formatMarkdownTable(["Name", "Fields", "Note"], rows);
           })
           .join("\n")
       : "";


### PR DESCRIPTION
## Summary

- Markdown documentation export produced raw tables where headers had hardcoded spacing but data rows had no padding, making the raw `.md` file misaligned and hard to read
- Added a `formatMarkdownTable(headers, rows)` helper that:
  - Calculates the maximum width per column (across header + all data rows)
  - Pads each cell with `padEnd()` to align columns
  - Generates the separator line with the correct number of dashes
- Applied to all three table types in the export: field tables, index tables, and type tables

## Before

```
| Name        | Type          | Settings                      | References                    | Note                           |
|-------------|---------------|-------------------------------|-------------------------------|--------------------------------|
| **id** | INTEGER | 🔑 PK, not null, autoincrement |  | |
| **name** | TEXT | null |  | |
```

## After

```
| Name     | Type    | Settings                       | References | Note |
| -------- | ------- | ------------------------------ | ---------- | ---- |
| **id**   | INTEGER | 🔑 PK, not null, autoincrement |            |      |
| **name** | TEXT    | null                           |            |      |
```

## Test plan

- [ ] Export a schema with multiple tables to Markdown
- [ ] Open the raw `.md` file and verify columns are aligned
- [ ] Verify tables with indexes and custom types are also aligned

Fixes #996