### PR TITLE
fix: correct FK direction when dragging from parent to child table

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -619,14 +619,28 @@ export default function Canvas() {
 
     const cardinality = getCardinality(startField, endField);
 
+    // Normalize direction: startTable must always be the FK holder (many side).
+    // When the user drags from the PK side (one) to the FK side (many), the
+    // result is ONE_TO_MANY with startTable = PK. Swap so that startTable = FK.
+    const isInverted = cardinality === Cardinality.ONE_TO_MANY;
+    const fkTableId = isInverted ? hoveredTable.tableId : linkingLine.startTableId;
+    const fkFieldId = isInverted ? hoveredTable.fieldId : linkingLine.startFieldId;
+    const refTableId = isInverted ? linkingLine.startTableId : hoveredTable.tableId;
+    const refFieldId = isInverted ? linkingLine.startFieldId : hoveredTable.fieldId;
+    const fkTableName = isInverted ? endTableName : startTableName;
+    const fkField = isInverted ? endField : startField;
+    const refTableName = isInverted ? startTableName : endTableName;
+
     const newRelationship = {
       ...linkingLine,
-      cardinality,
-      endTableId: hoveredTable.tableId,
-      endFieldId: hoveredTable.fieldId,
+      cardinality: isInverted ? Cardinality.MANY_TO_ONE : cardinality,
+      startTableId: fkTableId,
+      startFieldId: fkFieldId,
+      endTableId: refTableId,
+      endFieldId: refFieldId,
       updateConstraint: Constraint.NONE,
       deleteConstraint: Constraint.NONE,
-      name: `fk_${startTableName}_${startField.name}_${endTableName}`,
+      name: `fk_${fkTableName}_${fkField.name}_${refTableName}`,
       id: nanoid(),
     };
     delete newRelationship.startX;

--- a/src/utils/exportSQL/generic.js
+++ b/src/utils/exportSQL/generic.js
@@ -1,6 +1,6 @@
 import { DB } from "../../data/constants";
 import { dbToTypes, defaultTypes } from "../../data/datatypes";
-import { escapeQuotes, getInlineFK, parseDefault } from "./shared";
+import { escapeQuotes, getInlineFK, parseDefault, resolveFKDirection } from "./shared";
 
 export function getJsonType(f) {
   if (!Object.keys(defaultTypes).includes(f.type)) {
@@ -229,17 +229,17 @@ export function jsonToMySQL(obj) {
     )
     .join("\n")}\n${obj.references
     .map((r) => {
-      const { name: startName, fields: startFields } = obj.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = obj.tables.find(
+        (t) => t.id === fkTableId,
       );
-
-      const { name: endName, fields: endFields } = obj.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = obj.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE \`${startName}\`\nADD FOREIGN KEY(\`${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }\`) REFERENCES \`${endName}\`(\`${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE \`${fkName}\`\nADD FOREIGN KEY(\`${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }\`) REFERENCES \`${refName}\`(\`${
+        refFields.find((f) => f.id === refFieldId).name
       }\`)\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .join("\n")}`;
@@ -336,17 +336,17 @@ export function jsonToPostgreSQL(obj) {
     )
     .join("\n")}\n${obj.references
     .map((r) => {
-      const { name: startName, fields: startFields } = obj.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = obj.tables.find(
+        (t) => t.id === fkTableId,
       );
-
-      const { name: endName, fields: endFields } = obj.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = obj.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE "${startName}"\nADD FOREIGN KEY("${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }") REFERENCES "${endName}"("${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE "${fkName}"\nADD FOREIGN KEY("${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }") REFERENCES "${refName}"("${
+        refFields.find((f) => f.id === refFieldId).name
       }")\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .join("\n")}`;
@@ -474,17 +474,17 @@ export function jsonToMariaDB(obj) {
     )
     .join("\n")}\n${obj.references
     .map((r) => {
-      const { name: startName, fields: startFields } = obj.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = obj.tables.find(
+        (t) => t.id === fkTableId,
       );
-
-      const { name: endName, fields: endFields } = obj.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = obj.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE \`${startName}\`\nADD FOREIGN KEY(\`${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }\`) REFERENCES \`${endName}\`(\`${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE \`${fkName}\`\nADD FOREIGN KEY(\`${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }\`) REFERENCES \`${refName}\`(\`${
+        refFields.find((f) => f.id === refFieldId).name
       }\`)\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .join("\n")}`;
@@ -546,17 +546,17 @@ export function jsonToSQLServer(obj) {
     )
     .join("\n")}\n${obj.references
     .map((r) => {
-      const { name: startName, fields: startFields } = obj.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = obj.tables.find(
+        (t) => t.id === fkTableId,
       );
-
-      const { name: endName, fields: endFields } = obj.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = obj.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE [${startName}]\nADD FOREIGN KEY([${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }]) REFERENCES [${endName}]([${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE [${fkName}]\nADD FOREIGN KEY([${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }]) REFERENCES [${refName}]([${
+        refFields.find((f) => f.id === refFieldId).name
       }])\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};\nGO`;
     })
     .join("\n")}`;
@@ -619,17 +619,17 @@ export function jsonToOracleSQL(obj) {
     )
     .join("\n\n")}\n${obj.references
     .map((r) => {
-      const { name: startName, fields: startFields } = obj.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = obj.tables.find(
+        (t) => t.id === fkTableId,
       );
-
-      const { name: endName, fields: endFields } = obj.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = obj.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE "${startName}"\nADD CONSTRAINT "${r.name}" FOREIGN KEY ("${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }") REFERENCES "${endName}"("${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE "${fkName}"\nADD CONSTRAINT "${r.name}" FOREIGN KEY ("${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }") REFERENCES "${refName}"("${
+        refFields.find((f) => f.id === refFieldId).name
       }");`;
     })
     .join("\n")}`;

--- a/src/utils/exportSQL/mariadb.js
+++ b/src/utils/exportSQL/mariadb.js
@@ -1,4 +1,4 @@
-import { escapeQuotes, parseDefault } from "./shared";
+import { escapeQuotes, parseDefault, resolveFKDirection } from "./shared";
 
 import { dbToTypes } from "../../data/datatypes";
 import { DB } from "../../data/constants";
@@ -60,17 +60,17 @@ export function toMariaDB(diagram) {
     )
     .join("\n")}\n${diagram.references
     .map((r) => {
-      const { name: startName, fields: startFields } = diagram.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = diagram.tables.find(
+        (t) => t.id === fkTableId,
       );
-
-      const { name: endName, fields: endFields } = diagram.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = diagram.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE \`${startName}\`\nADD FOREIGN KEY(\`${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }\`) REFERENCES \`${endName}\`(\`${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE \`${fkName}\`\nADD FOREIGN KEY(\`${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }\`) REFERENCES \`${refName}\`(\`${
+        refFields.find((f) => f.id === refFieldId).name
       }\`)\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .join("\n")}`;

--- a/src/utils/exportSQL/mssql.js
+++ b/src/utils/exportSQL/mssql.js
@@ -1,4 +1,4 @@
-import { parseDefault, escapeQuotes } from "./shared";
+import { parseDefault, escapeQuotes, resolveFKDirection } from "./shared";
 
 import { dbToTypes } from "../../data/datatypes";
 import { DB } from "../../data/constants";
@@ -94,19 +94,20 @@ export function toMSSQL(diagram) {
 
   const referencesSql = diagram.references
     .map((r) => {
-      const startTable = diagram.tables.find((t) => t.id === r.startTableId);
-      const endTable = diagram.tables.find((t) => t.id === r.endTableId);
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const fkTable = diagram.tables.find((t) => t.id === fkTableId);
+      const refTable = diagram.tables.find((t) => t.id === refTableId);
 
-      if (!startTable || !endTable) return "";
+      if (!fkTable || !refTable) return "";
 
-      const startField = startTable.fields.find((f) => f.id === r.startFieldId);
-      const endField = endTable.fields.find((f) => f.id === r.endFieldId);
+      const fkField = fkTable.fields.find((f) => f.id === fkFieldId);
+      const refField = refTable.fields.find((f) => f.id === refFieldId);
 
-      if (!startField || !endField) return "";
+      if (!fkField || !refField) return "";
 
-      return `\nALTER TABLE [${startTable.name}]
-ADD FOREIGN KEY([${startField.name}])
-REFERENCES [${endTable.name}]([${endField.name}])
+      return `\nALTER TABLE [${fkTable.name}]
+ADD FOREIGN KEY([${fkField.name}])
+REFERENCES [${refTable.name}]([${refField.name}])
 ON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};
 GO`;
     })

--- a/src/utils/exportSQL/mysql.js
+++ b/src/utils/exportSQL/mysql.js
@@ -1,7 +1,7 @@
 import { escapeQuotes, parseDefault } from "./shared";
 
 import { dbToTypes } from "../../data/datatypes";
-import { DB } from "../../data/constants";
+import { Cardinality, DB } from "../../data/constants";
 
 function parseType(field) {
   let res = field.type;
@@ -64,17 +64,22 @@ export function toMySQL(diagram) {
     )
     .join("\n")}\n${diagram.references
     .map((r) => {
-      const { name: startName, fields: startFields } = diagram.tables.find(
-        (t) => t.id === r.startTableId,
-      );
+      const isInverted = r.cardinality === Cardinality.ONE_TO_MANY;
+      const fkTableId = isInverted ? r.endTableId : r.startTableId;
+      const fkFieldId = isInverted ? r.endFieldId : r.startFieldId;
+      const refTableId = isInverted ? r.startTableId : r.endTableId;
+      const refFieldId = isInverted ? r.startFieldId : r.endFieldId;
 
-      const { name: endName, fields: endFields } = diagram.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: fkName, fields: fkFields } = diagram.tables.find(
+        (t) => t.id === fkTableId,
       );
-      return `ALTER TABLE \`${startName}\`\nADD FOREIGN KEY(\`${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }\`) REFERENCES \`${endName}\`(\`${
-        endFields.find((f) => f.id === r.endFieldId).name
+      const { name: refName, fields: refFields } = diagram.tables.find(
+        (t) => t.id === refTableId,
+      );
+      return `ALTER TABLE \`${fkName}\`\nADD FOREIGN KEY(\`${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }\`) REFERENCES \`${refName}\`(\`${
+        refFields.find((f) => f.id === refFieldId).name
       }\`)\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .join("\n")}`;

--- a/src/utils/exportSQL/oraclesql.js
+++ b/src/utils/exportSQL/oraclesql.js
@@ -1,5 +1,5 @@
 import { dbToTypes } from "../../data/datatypes";
-import { parseDefault } from "./shared";
+import { parseDefault, resolveFKDirection } from "./shared";
 
 export function toOracleSQL(diagram) {
   return `${diagram.tables
@@ -47,16 +47,17 @@ export function toOracleSQL(diagram) {
     )
     .join("\n")}\n${diagram.references
     .map((r) => {
-      const { name: startName, fields: startFields } = diagram.tables.find(
-        (t) => t.id === r.startTableId,
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const { name: fkName, fields: fkFields } = diagram.tables.find(
+        (t) => t.id === fkTableId,
       );
-      const { name: endName, fields: endFields } = diagram.tables.find(
-        (t) => t.id === r.endTableId,
+      const { name: refName, fields: refFields } = diagram.tables.find(
+        (t) => t.id === refTableId,
       );
-      return `ALTER TABLE "${startName}"\nADD CONSTRAINT "${r.name}" FOREIGN KEY ("${
-        startFields.find((f) => f.id === r.startFieldId).name
-      }") REFERENCES "${endName}" ("${
-        endFields.find((f) => f.id === r.endFieldId).name
+      return `ALTER TABLE "${fkName}"\nADD CONSTRAINT "${r.name}" FOREIGN KEY ("${
+        fkFields.find((f) => f.id === fkFieldId).name
+      }") REFERENCES "${refName}" ("${
+        refFields.find((f) => f.id === refFieldId).name
       }")\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .join("\n")}`;

--- a/src/utils/exportSQL/postgres.js
+++ b/src/utils/exportSQL/postgres.js
@@ -1,4 +1,4 @@
-import { escapeQuotes, exportFieldComment, parseDefault } from "./shared";
+import { escapeQuotes, exportFieldComment, parseDefault, resolveFKDirection } from "./shared";
 import { dbToTypes } from "../../data/datatypes";
 
 export function toPostgres(diagram) {
@@ -87,16 +87,15 @@ export function toPostgres(diagram) {
 
   const foreignKeyStatements = diagram.references
     .map((r) => {
-      const startTable = diagram.tables.find((t) => t.id === r.startTableId);
-      const endTable = diagram.tables.find((t) => t.id === r.endTableId);
-      const startField = startTable?.fields.find(
-        (f) => f.id === r.startFieldId,
-      );
-      const endField = endTable?.fields.find((f) => f.id === r.endFieldId);
+      const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+      const fkTable = diagram.tables.find((t) => t.id === fkTableId);
+      const refTable = diagram.tables.find((t) => t.id === refTableId);
+      const fkField = fkTable?.fields.find((f) => f.id === fkFieldId);
+      const refField = refTable?.fields.find((f) => f.id === refFieldId);
 
-      if (!startTable || !endTable || !startField || !endField) return "";
+      if (!fkTable || !refTable || !fkField || !refField) return "";
 
-      return `ALTER TABLE "${startTable.name}"\nADD FOREIGN KEY("${startField.name}") REFERENCES "${endTable.name}"("${endField.name}")\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
+      return `ALTER TABLE "${fkTable.name}"\nADD FOREIGN KEY("${fkField.name}") REFERENCES "${refTable.name}"("${refField.name}")\nON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()};`;
     })
     .filter(Boolean)
     .join("\n");

--- a/src/utils/exportSQL/shared.js
+++ b/src/utils/exportSQL/shared.js
@@ -1,6 +1,6 @@
 import { isFunction, isKeyword } from "../utils";
 
-import { DB } from "../../data/constants";
+import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
 
 export function parseDefault(field, database = DB.GENERIC) {
@@ -30,17 +30,28 @@ export function exportFieldComment(comment) {
     .join("");
 }
 
+export function resolveFKDirection(r) {
+  const isInverted = r.cardinality === Cardinality.ONE_TO_MANY;
+  return {
+    fkTableId: isInverted ? r.endTableId : r.startTableId,
+    fkFieldId: isInverted ? r.endFieldId : r.startFieldId,
+    refTableId: isInverted ? r.startTableId : r.endTableId,
+    refFieldId: isInverted ? r.startFieldId : r.endFieldId,
+  };
+}
+
 export function getInlineFK(table, obj) {
   let fks = [];
   obj.references.forEach((r) => {
-    if (r.startTableId === table.id) {
+    const { fkTableId, fkFieldId, refTableId, refFieldId } = resolveFKDirection(r);
+    if (fkTableId === table.id) {
       fks.push(
-        `\tFOREIGN KEY ("${table.fields.find((f) => f.id === r.startFieldId)?.name}") REFERENCES "${
-          obj.tables.find((t) => t.id === r.endTableId)?.name
+        `\tFOREIGN KEY ("${table.fields.find((f) => f.id === fkFieldId)?.name}") REFERENCES "${
+          obj.tables.find((t) => t.id === refTableId)?.name
         }"("${
           obj.tables
-            .find((t) => t.id === r.endTableId)
-            .fields.find((f) => f.id === r.endFieldId)?.name
+            .find((t) => t.id === refTableId)
+            .fields.find((f) => f.id === refFieldId)?.name
         }")\n\tON UPDATE ${r.updateConstraint.toUpperCase()} ON DELETE ${r.deleteConstraint.toUpperCase()}`,
       );
     }


### PR DESCRIPTION
## Summary

When a user drags from a primary key field (the "one"/parent side) to a non-unique field (the "many"/child side), the relationship was stored with the PK table as `startTable`. Since all SQL exporters generate `ALTER TABLE [startTable] ADD FOREIGN KEY(...)`, this produced incorrect SQL that placed the FK constraint on the parent (referenced) table instead of the child (FK holder) table.

**Two complementary fixes:**

**Fix A — Normalize at creation time** (`Canvas.jsx`): When `getCardinality()` returns `ONE_TO_MANY` (start field is unique/PK, end field is not), swap `startTable`/`endTable` and change cardinality to `MANY_TO_ONE`. This ensures `startTable` always represents the FK holder going forward.

**Fix B — Safety net in exporters** (`shared.js` + all SQL exporters): Added `resolveFKDirection(r)` helper that checks if a relationship has `ONE_TO_MANY` cardinality and swaps the FK/referenced table assignment accordingly. This handles any pre-existing diagrams saved before this fix.

## Before

```sql
-- User drags from members.id (PK) → memberships.member_id
-- Wrong: FK placed on the referenced table
ALTER TABLE `members`
ADD FOREIGN KEY(`id`) REFERENCES `memberships`(`member_id`)
```

## After

```sql
-- Correct: FK placed on the child table
ALTER TABLE `memberships`
ADD FOREIGN KEY(`member_id`) REFERENCES `members`(`id`)
```

## Files changed

- `src/components/EditorCanvas/Canvas.jsx` — normalize direction at creation time
- `src/utils/exportSQL/shared.js` — add `resolveFKDirection()` helper
- `src/utils/exportSQL/mysql.js`, `mariadb.js`, `postgres.js`, `mssql.js`, `oraclesql.js` — use `resolveFKDirection()`
- `src/utils/exportSQL/generic.js` — all 5 FK sections updated

## Test plan

- [ ] Create a `members` (id PK) and `memberships` (member_id) table
- [ ] Drag from `members.id` to `memberships.member_id` to create a 1:N relationship
- [ ] Export to SQL — verify `ALTER TABLE memberships ADD FOREIGN KEY(member_id) REFERENCES members(id)`
- [ ] Drag in reverse (from `memberships.member_id` to `members.id`) — verify same correct output
- [ ] Load an old diagram with a `ONE_TO_MANY` relationship and verify export is now correct

Fixes #873