### PR TITLE
fix: add missing pipe delimiters in Markdown table rows

### DIFF
--- a/src/utils/exportAs/documentation.js
+++ b/src/utils/exportAs/documentation.js
@@ -12,10 +12,10 @@ function formatMarkdownTable(headers, rows) {
   const separator = colWidths.map((w) => "-".repeat(w)).join(" | ");
   const headerRow = headers.map((h, i) => pad(h, colWidths[i])).join(" | ");
   const dataRows = rows
-    .map((row) => row.map((cell, i) => pad(cell, colWidths[i])).join(" | "))
+    .map((row) => `| ${row.map((cell, i) => pad(cell, colWidths[i])).join(" | ")} |`)
     .join("\n");
 
-  return `| ${headerRow} |\n| ${separator} |\n| ${dataRows} |`;
+  return `| ${headerRow} |\n| ${separator} |\n${dataRows}`;
 }
 
 export function jsonToDocumentation(obj) {


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #1000 where only the first data row of exported Markdown tables had proper `|` delimiters — subsequent rows were missing the leading pipe, breaking the table structure.

## Before / After

**Before (broken):**
```md
| Column A  | Column B | Column C |
| --------- | -------- | -------- |
| **row1**  | value1   | value1   |
**row2**    | value2   | value2
**row3**    | value3   | value3   |
```

**After (fixed):**
```md
| Column A  | Column B | Column C |
| --------- | -------- | -------- |
| **row1**  | value1   | value1   |
| **row2**  | value2   | value2   |
| **row3**  | value3   | value3   |
```

## Test plan
- [ ] Export a schema with multiple fields per table to Markdown
- [ ] Verify all rows have correct `|` delimiters in the raw `.md` output
- [ ] Check index and type tables as well

Closes #996