### PR TITLE
feat: add PostgreSQL direct connection to reverse-engineer ER diagrams

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=http://backend.com
+VITE_BACKEND_URL=http://localhost:3001

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,20 @@ services:
     command: sh -c "npm install && npm run dev -- --host"
     networks:
       - default
+  drawdb-server:
+    image: node:20-alpine
+    container_name: drawdb-server
+    ports:
+      - 3001:3001
+    working_dir: /var/www/html/server
+    volumes:
+      - ./server:/var/www/html/server
+    command: sh -c "npm install && node index.js"
+    environment:
+      - PORT=3001
+      - ALLOWED_ORIGINS=http://localhost:5173
+    networks:
+      - default
 
 networks:
   default:

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+PORT=3001
+ALLOWED_ORIGINS=http://localhost:5173

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,61 @@
+import "dotenv/config";
+import express from "express";
+import cors from "cors";
+import { generateDDL } from "./lib/generateDDL.js";
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+const ALLOWED_ORIGINS = (
+  process.env.ALLOWED_ORIGINS || "http://localhost:5173"
+).split(",");
+
+app.use(
+  cors({
+    origin: ALLOWED_ORIGINS,
+    methods: ["POST"],
+    allowedHeaders: ["Content-Type"],
+  }),
+);
+app.use(express.json());
+
+app.post("/api/schema/postgres", async (req, res) => {
+  const { host, port, database, user, password, schema: schemaName, ssl } = req.body;
+
+  if (!host || !database || !user) {
+    return res.status(400).json({
+      error: "Missing required fields: host, database, user",
+    });
+  }
+
+  try {
+    const result = await generateDDL({
+      host,
+      port: port || 5432,
+      database,
+      user,
+      password: password || "",
+      schema: schemaName || "public",
+      ssl: ssl || false,
+    });
+    res.json(result);
+  } catch (err) {
+    const msg = err.message || "Unknown error";
+
+    if (msg.includes("ECONNREFUSED") || msg.includes("ENOTFOUND")) {
+      return res.status(502).json({ error: `Connection refused: ${msg}` });
+    }
+    if (msg.includes("authentication") || msg.includes("password")) {
+      return res.status(401).json({ error: "Authentication failed" });
+    }
+    if (msg.includes("does not exist") || msg.includes("3D000")) {
+      return res.status(404).json({ error: `Database not found: ${database}` });
+    }
+
+    res.status(500).json({ error: msg });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`drawdb-server listening on port ${PORT}`);
+  console.log(`Allowed origins: ${ALLOWED_ORIGINS.join(", ")}`);
+});

--- a/server/lib/generateDDL.js
+++ b/server/lib/generateDDL.js
@@ -1,0 +1,400 @@
+import pg from "pg";
+
+const QUERY_TIMEOUT_MS = 10_000;
+
+/**
+ * Connect to PostgreSQL, introspect schema, and generate DDL.
+ * Uses a temporary connection — credentials are never stored.
+ */
+export async function generateDDL({ host, port, database, user, password, schema, ssl }) {
+  const client = new pg.Client({
+    host,
+    port,
+    database,
+    user,
+    password,
+    ssl: ssl ? { rejectUnauthorized: false } : undefined,
+    statement_timeout: QUERY_TIMEOUT_MS,
+    query_timeout: QUERY_TIMEOUT_MS,
+    connectionTimeoutMillis: QUERY_TIMEOUT_MS,
+  });
+
+  try {
+    await client.connect();
+    const ddl = [];
+
+    // 1. Enum types
+    ddl.push(...(await enumTypes(client, schema)));
+
+    // 2. Composite types
+    ddl.push(...(await compositeTypes(client, schema)));
+
+    // 3. Tables + columns
+    ddl.push(...(await tableColumns(client, schema)));
+
+    // 4. Primary keys (ALTER for composite PKs)
+    ddl.push(...(await primaryKeys(client, schema)));
+
+    // 5. Unique constraints
+    ddl.push(...(await uniqueConstraints(client, schema)));
+
+    // 6. Foreign keys
+    ddl.push(...(await foreignKeys(client, schema)));
+
+    // 7. Indexes (exclude PK/UK)
+    ddl.push(...(await indexes(client, schema)));
+
+    // 8. Comments
+    ddl.push(...(await comments(client, schema)));
+
+    const sql = ddl.join("\n\n");
+
+    // Count tables and FK relationships for the response
+    const countResult = await client.query(
+      `SELECT count(*)::int AS tables FROM information_schema.tables
+       WHERE table_schema = $1 AND table_type = 'BASE TABLE'`,
+      [schema],
+    );
+    const fkCountResult = await client.query(
+      `SELECT count(*)::int AS rels FROM information_schema.table_constraints
+       WHERE table_schema = $1 AND constraint_type = 'FOREIGN KEY'`,
+      [schema],
+    );
+
+    return {
+      sql,
+      tables: countResult.rows[0].tables,
+      relationships: fkCountResult.rows[0].rels,
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+// ── 1. Enum Types ──────────────────────────────────────────────────────────
+
+async function enumTypes(client, schema) {
+  const { rows } = await client.query(
+    `SELECT t.typname, e.enumlabel
+     FROM pg_type t
+     JOIN pg_enum e ON t.oid = e.enumtypid
+     JOIN pg_namespace n ON t.typnamespace = n.oid
+     WHERE n.nspname = $1
+     ORDER BY t.typname, e.enumsortorder`,
+    [schema],
+  );
+
+  const groups = {};
+  for (const row of rows) {
+    (groups[row.typname] ??= []).push(row.enumlabel);
+  }
+
+  return Object.entries(groups).map(
+    ([name, values]) => `CREATE TYPE ${q(name)} AS ENUM (${values.map((v) => `'${v}'`).join(", ")});`,
+  );
+}
+
+// ── 2. Composite Types ─────────────────────────────────────────────────────
+
+async function compositeTypes(client, schema) {
+  const { rows } = await client.query(
+    `SELECT t.typname, a.attname, format_type(a.atttypid, a.atttypmod) AS data_type
+     FROM pg_type t
+     JOIN pg_namespace n ON t.typnamespace = n.oid
+     JOIN pg_attribute a ON a.attrelid = t.typrelid
+     WHERE n.nspname = $1 AND t.typtype = 'c' AND a.attnum > 0 AND NOT a.attisdropped
+     ORDER BY t.typname, a.attnum`,
+    [schema],
+  );
+
+  const groups = {};
+  for (const row of rows) {
+    (groups[row.typname] ??= []).push({ name: row.attname, type: row.data_type });
+  }
+
+  return Object.entries(groups).map(
+    ([name, fields]) =>
+      `CREATE TYPE ${q(name)} AS (${fields.map((f) => `${q(f.name)} ${f.type}`).join(", ")});`,
+  );
+}
+
+// ── 3. Tables + Columns ────────────────────────────────────────────────────
+
+async function tableColumns(client, schema) {
+  const { rows } = await client.query(
+    `SELECT
+       c.table_name,
+       c.column_name,
+       c.data_type,
+       c.udt_name,
+       c.character_maximum_length,
+       c.numeric_precision,
+       c.numeric_scale,
+       c.column_default,
+       c.is_nullable,
+       c.is_identity,
+       CASE WHEN c.is_identity = 'YES' THEN 'ALWAYS' END AS identity,
+       CASE WHEN EXISTS (
+         SELECT 1 FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+           ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+         WHERE tc.table_schema = $1 AND tc.table_name = c.table_name
+           AND tc.constraint_type = 'PRIMARY KEY' AND kcu.column_name = c.column_name
+       ) THEN true ELSE false END AS is_primary
+     FROM information_schema.columns c
+     WHERE c.table_schema = $1
+       AND c.table_name IN (
+         SELECT table_name FROM information_schema.tables
+         WHERE table_schema = $1 AND table_type = 'BASE TABLE'
+       )
+     ORDER BY c.table_name, c.ordinal_position`,
+    [schema],
+  );
+
+  const tables = {};
+  for (const col of rows) {
+    (tables[col.table_name] ??= []).push(col);
+  }
+
+  return Object.entries(tables).map(([table, cols]) => {
+    const colDefs = cols.map((c) => {
+      const parts = [`  ${q(c.column_name)}`];
+      parts.push(columnType(c));
+
+      if (c.is_primary && cols.filter((x) => x.is_primary).length === 1) {
+        parts.push("PRIMARY KEY");
+      }
+      if (c.is_identity === "YES") parts.push("GENERATED ALWAYS AS IDENTITY");
+      if (c.is_nullable === "NO" && !c.is_primary) parts.push("NOT NULL");
+      if (c.column_default != null && c.is_identity !== "YES") {
+        parts.push(`DEFAULT ${c.column_default}`);
+      }
+
+      return parts.join(" ");
+    });
+
+    return `CREATE TABLE ${q(table)} (\n${colDefs.join(",\n")}\n);`;
+  });
+}
+
+function columnType(c) {
+  const udt = c.udt_name;
+
+  // Array types start with underscore in pg_type
+  if (udt.startsWith("_")) {
+    const inner = udt.slice(1);
+    return `${upperInner(inner)}[]`;
+  }
+
+  if (c.data_type === "USER-DEFINED") return udt; // enum / composite
+  if (c.data_type === "character varying") return `VARCHAR(${c.character_maximum_length ?? ""})`;
+  if (c.data_type === "character") return `CHAR(${c.character_maximum_length ?? ""})`;
+  if (c.data_type === "numeric" && c.numeric_precision != null) {
+    return c.numeric_scale != null
+      ? `NUMERIC(${c.numeric_precision},${c.numeric_scale})`
+      : `NUMERIC(${c.numeric_precision})`;
+  }
+
+  return upperInner(udt);
+}
+
+function upperInner(udt) {
+  // Common PostgreSQL built-in type mappings
+  const map = {
+    int4: "INTEGER",
+    int8: "BIGINT",
+    int2: "SMALLINT",
+    float4: "REAL",
+    float8: "DOUBLE PRECISION",
+    bool: "BOOLEAN",
+    varchar: "VARCHAR",
+    bpchar: "CHAR",
+    text: "TEXT",
+    date: "DATE",
+    time: "TIME",
+    timetz: "TIME WITH TIME ZONE",
+    timestamp: "TIMESTAMP",
+    timestamptz: "TIMESTAMP WITH TIME ZONE",
+    uuid: "UUID",
+    json: "JSON",
+    jsonb: "JSONB",
+    bytea: "BYTEA",
+    money: "MONEY",
+    bit: "BIT",
+    varbit: "BIT VARYING",
+    cidr: "CIDR",
+    inet: "INET",
+    macaddr: "MACADDR",
+    point: "POINT",
+    line: "LINE",
+    lseg: "LSEG",
+    box: "BOX",
+    path: "PATH",
+    polygon: "POLYGON",
+    circle: "CIRCLE",
+    interval: "INTERVAL",
+    xml: "XML",
+    tsvector: "TSVECTOR",
+    tsquery: "TSQUERY",
+  };
+  return map[udt] || udt.toUpperCase();
+}
+
+// ── 4. Primary Keys ────────────────────────────────────────────────────────
+
+async function primaryKeys(client, schema) {
+  const { rows } = await client.query(
+    `SELECT
+       tc.table_name,
+       kcu.column_name,
+       kcu.ordinal_position
+     FROM information_schema.table_constraints tc
+     JOIN information_schema.key_column_usage kcu
+       ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+     WHERE tc.table_schema = $1 AND tc.constraint_type = 'PRIMARY KEY'
+     ORDER BY tc.table_name, tc.constraint_name, kcu.ordinal_position`,
+    [schema],
+  );
+
+  // Group by (table, constraint)
+  const groups = {};
+  for (const row of rows) {
+    const key = `${row.table_name}`;
+    (groups[key] ??= []).push(row.column_name);
+  }
+
+  // Only emit ALTER for composite PKs; single-col PKs are inline
+  return Object.entries(groups)
+    .filter(([, cols]) => cols.length > 1)
+    .map(
+      ([table, cols]) =>
+        `ALTER TABLE ${q(table)} ADD PRIMARY KEY (${cols.map(q).join(", ")});`,
+    );
+}
+
+// ── 5. Unique Constraints ──────────────────────────────────────────────────
+
+async function uniqueConstraints(client, schema) {
+  const { rows } = await client.query(
+    `SELECT
+       tc.table_name,
+       tc.constraint_name,
+       kcu.column_name,
+       kcu.ordinal_position
+     FROM information_schema.table_constraints tc
+     JOIN information_schema.key_column_usage kcu
+       ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+     WHERE tc.table_schema = $1 AND tc.constraint_type = 'UNIQUE'
+     ORDER BY tc.table_name, tc.constraint_name, kcu.ordinal_position`,
+    [schema],
+  );
+
+  const groups = {};
+  for (const row of rows) {
+    const key = `${row.table_name}::${row.constraint_name}`;
+    (groups[key] ??= { table: row.table_name, cols: [] }).cols.push(row.column_name);
+  }
+
+  return Object.values(groups).map(
+    ({ table, cols }) =>
+      `ALTER TABLE ${q(table)} ADD UNIQUE (${cols.map(q).join(", ")});`,
+  );
+}
+
+// ── 6. Foreign Keys ────────────────────────────────────────────────────────
+
+async function foreignKeys(client, schema) {
+  const { rows } = await client.query(
+    `SELECT
+       tc.table_name,
+       kcu.column_name,
+       ccu.table_name AS referenced_table,
+       ccu.column_name AS referenced_column,
+       rc.update_rule,
+       rc.delete_rule
+     FROM information_schema.table_constraints tc
+     JOIN information_schema.key_column_usage kcu
+       ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+     JOIN information_schema.referential_constraints rc
+       ON tc.constraint_name = rc.constraint_name AND tc.table_schema = rc.constraint_schema
+     JOIN information_schema.constraint_column_usage ccu
+       ON rc.unique_constraint_name = ccu.constraint_name AND rc.unique_constraint_schema = ccu.table_schema
+     WHERE tc.table_schema = $1 AND tc.constraint_type = 'FOREIGN KEY'
+     ORDER BY tc.table_name, tc.constraint_name`,
+    [schema],
+  );
+
+  return rows.map((r) => {
+    let sql = `ALTER TABLE ${q(r.table_name)} ADD FOREIGN KEY (${q(r.column_name)}) REFERENCES ${q(r.referenced_table)}(${q(r.referenced_column)})`;
+    if (r.update_rule !== "NO ACTION") sql += ` ON UPDATE ${r.update_rule}`;
+    if (r.delete_rule !== "NO ACTION") sql += ` ON DELETE ${r.delete_rule}`;
+    return sql + ";";
+  });
+}
+
+// ── 7. Indexes ─────────────────────────────────────────────────────────────
+
+async function indexes(client, schema) {
+  const { rows } = await client.query(
+    `SELECT indexname, tablename, indexdef
+     FROM pg_indexes
+     WHERE schemaname = $1
+       AND indexname NOT LIKE '%_pkey'
+       AND indexname NOT LIKE '%_key'
+     ORDER BY tablename, indexname`,
+    [schema],
+  );
+
+  return rows.map((r) => `${r.indexdef};`);
+}
+
+// ── 8. Comments ────────────────────────────────────────────────────────────
+
+async function comments(client, schema) {
+  const result = [];
+
+  // Table comments
+  const tableComments = await client.query(
+    `SELECT c.relname AS table_name, d.description
+     FROM pg_description d
+     JOIN pg_class c ON d.objoid = c.oid
+     JOIN pg_namespace n ON c.relnamespace = n.oid
+     WHERE n.nspname = $1 AND d.objsubid = 0 AND d.description IS NOT NULL
+     ORDER BY c.relname`,
+    [schema],
+  );
+
+  for (const row of tableComments.rows) {
+    result.push(`COMMENT ON TABLE ${q(row.table_name)} IS '${escapeStr(row.description)}';`);
+  }
+
+  // Column comments
+  const colComments = await client.query(
+    `SELECT c.relname AS table_name, a.attname AS column_name, d.description
+     FROM pg_description d
+     JOIN pg_class c ON d.objoid = c.oid
+     JOIN pg_attribute a ON d.objoid = a.attrelid AND d.objsubid = a.attnum
+     JOIN pg_namespace n ON c.relnamespace = n.oid
+     WHERE n.nspname = $1 AND d.objsubid > 0 AND d.description IS NOT NULL
+     ORDER BY c.relname, a.attname`,
+    [schema],
+  );
+
+  for (const row of colComments.rows) {
+    result.push(
+      `COMMENT ON COLUMN ${q(row.table_name)}.${q(row.column_name)} IS '${escapeStr(row.description)}';`,
+    );
+  }
+
+  return result;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function q(identifier) {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function escapeStr(s) {
+  return s.replace(/'/g, "''");
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "drawdb-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "pg": "^8.13.1"
+  }
+}

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const baseUrl = import.meta.env.VITE_BACKEND_URL;
+
+export async function fetchPostgresSchema(params) {
+  const res = await axios.post(`${baseUrl}/api/schema/postgres`, params);
+  return res.data;
+}

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -932,6 +932,14 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
               label: "Beta",
               disabled: layout.readOnly,
             },
+            { divider: true },
+            {
+              function: () => {
+                setModal(MODAL.IMPORT_DB);
+              },
+              name: t("connect_database"),
+              disabled: layout.readOnly,
+            },
           ],
         }),
         function: () => {

--- a/src/components/EditorHeader/Modal/ImportDatabase.jsx
+++ b/src/components/EditorHeader/Modal/ImportDatabase.jsx
@@ -1,0 +1,142 @@
+import { Checkbox, Banner, Switch } from "@douyinfe/semi-ui";
+import { STATUS } from "../../../data/constants";
+import { useTranslation } from "react-i18next";
+
+export default function ImportDatabase({
+  connectionParams,
+  setConnectionParams,
+  error,
+  setError,
+  dbLoading,
+}) {
+  const { t } = useTranslation();
+
+  const update = (key, value) => {
+    setConnectionParams((prev) => ({ ...prev, [key]: value }));
+    if (error.type === STATUS.ERROR) {
+      setError({ type: STATUS.NONE, message: "" });
+    }
+  };
+
+  const noBackend = !import.meta.env.VITE_BACKEND_URL;
+
+  return (
+    <div>
+      {noBackend && (
+        <Banner
+          type="warning"
+          fullMode={false}
+          description={t("no_backend")}
+          className="mb-4"
+        />
+      )}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("host")}</label>
+          <input
+            className="w-full border rounded px-3 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-600"
+            placeholder="localhost"
+            value={connectionParams.host}
+            onChange={(e) => update("host", e.target.value)}
+            disabled={dbLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">{t("port")}</label>
+          <input
+            className="w-full border rounded px-3 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-600"
+            placeholder="5432"
+            value={connectionParams.port}
+            onChange={(e) => update("port", e.target.value)}
+            disabled={dbLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("database_name")}
+          </label>
+          <input
+            className="w-full border rounded px-3 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-600"
+            placeholder="mydb"
+            value={connectionParams.database}
+            onChange={(e) => update("database", e.target.value)}
+            disabled={dbLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("schema")}
+          </label>
+          <input
+            className="w-full border rounded px-3 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-600"
+            placeholder="public"
+            value={connectionParams.schema}
+            onChange={(e) => update("schema", e.target.value)}
+            disabled={dbLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("username")}
+          </label>
+          <input
+            className="w-full border rounded px-3 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-600"
+            placeholder="postgres"
+            value={connectionParams.user}
+            onChange={(e) => update("user", e.target.value)}
+            disabled={dbLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            {t("password")}
+          </label>
+          <input
+            type="password"
+            className="w-full border rounded px-3 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-600"
+            placeholder="••••••••"
+            value={connectionParams.password}
+            onChange={(e) => update("password", e.target.value)}
+            disabled={dbLoading}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 mt-4">
+        <Switch
+          checked={connectionParams.ssl}
+          onChange={(v) => update("ssl", v)}
+          disabled={dbLoading}
+        />
+        <span className="text-sm">SSL</span>
+      </div>
+
+      <div className="mt-4">
+        <Checkbox
+          checked={connectionParams.overwrite}
+          onChange={(e) => update("overwrite", e.target.checked)}
+          disabled={dbLoading}
+        >
+          {t("overwrite_existing_diagram")}
+        </Checkbox>
+      </div>
+
+      <div className="mt-2">
+        {error.type === STATUS.ERROR && (
+          <Banner
+            type="danger"
+            fullMode={false}
+            description={<div>{error.message}</div>}
+          />
+        )}
+        {error.type === STATUS.OK && (
+          <Banner
+            type="info"
+            fullMode={false}
+            description={<div>{error.message}</div>}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditorHeader/Modal/Modal.jsx
+++ b/src/components/EditorHeader/Modal/Modal.jsx
@@ -18,12 +18,14 @@ import {
 } from "../../../hooks";
 import { isRtl } from "../../../i18n/utils/rtl";
 import { importSQL } from "../../../utils/importSQL";
+import { fetchPostgresSchema } from "../../../api/schema";
 import {
   getModalTitle,
   getModalWidth,
   getOkText,
 } from "../../../utils/modalData";
 import CodeEditor from "../../CodeEditor";
+import ImportDatabase from "./ImportDatabase";
 import ImportDiagram from "./ImportDiagram";
 import ImportSource from "./ImportSource";
 import Language from "./Language";
@@ -70,6 +72,17 @@ export default function Modal({
     src: "",
     overwrite: false,
   });
+  const [connectionParams, setConnectionParams] = useState({
+    host: "localhost",
+    port: "5432",
+    database: "",
+    user: "postgres",
+    password: "",
+    schema: "public",
+    ssl: false,
+    overwrite: false,
+  });
+  const [dbLoading, setDbLoading] = useState(false);
   const [importData, setImportData] = useState(null);
   const [error, setError] = useState({
     type: STATUS.NONE,
@@ -193,6 +206,51 @@ export default function Modal({
       case MODAL.IMPORT_SRC:
         parseSQLAndLoadDiagram();
         return;
+      case MODAL.IMPORT_DB:
+        (async () => {
+          setDbLoading(true);
+          setError({ type: STATUS.NONE, message: "" });
+          try {
+            const { overwrite, ...params } = connectionParams;
+            const result = await fetchPostgresSchema(params);
+
+            const parser = new Parser();
+            const ast = parser.astify(result.sql, { database: DB.POSTGRES });
+            const diagramData = importSQL(ast, DB.POSTGRES, database);
+
+            if (overwrite) {
+              setTables(diagramData.tables);
+              setRelationships(diagramData.relationships);
+              if (databases[database].hasTypes) setTypes(diagramData.types ?? []);
+              if (databases[database].hasEnums) setEnums(diagramData.enums ?? []);
+              setTransform((prev) => ({ ...prev, pan: { x: 0, y: 0 } }));
+              setNotes([]);
+              setAreas([]);
+            } else {
+              setTables((prev) => [...prev, ...diagramData.tables]);
+              setRelationships((prev) =>
+                [...prev, ...diagramData.relationships].map((r, i) => ({
+                  ...r,
+                  id: i,
+                })),
+              );
+              if (databases[database].hasTypes && diagramData.types?.length)
+                setTypes((prev) => [...prev, ...diagramData.types]);
+              if (databases[database].hasEnums && diagramData.enums?.length)
+                setEnums((prev) => [...prev, ...diagramData.enums]);
+            }
+
+            setUndoStack([]);
+            setRedoStack([]);
+            setModal(MODAL.NONE);
+          } catch (e) {
+            const msg = e.response?.data?.error || e.message || String(e);
+            setError({ type: STATUS.ERROR, message: msg });
+          } finally {
+            setDbLoading(false);
+          }
+        })();
+        return;
       case MODAL.OPEN:
         if (!selectedDiagramId) return;
         navigate(`/editor/diagrams/${selectedDiagramId}`, "_blank");
@@ -242,6 +300,16 @@ export default function Modal({
             setImportData={setImportSource}
             error={error}
             setError={setError}
+          />
+        );
+      case MODAL.IMPORT_DB:
+        return (
+          <ImportDatabase
+            connectionParams={connectionParams}
+            setConnectionParams={setConnectionParams}
+            error={error}
+            setError={setError}
+            dbLoading={dbLoading}
           />
         );
       case MODAL.NEW:
@@ -347,6 +415,17 @@ export default function Modal({
           src: "",
           overwrite: false,
         });
+        setConnectionParams({
+          host: "localhost",
+          port: "5432",
+          database: "",
+          user: "postgres",
+          password: "",
+          schema: "public",
+          ssl: false,
+          overwrite: false,
+        });
+        setDbLoading(false);
       }}
       onCancel={() => {
         if (modal === MODAL.RENAME) setUncontrolledTitle(title);
@@ -365,7 +444,8 @@ export default function Modal({
           (modal === MODAL.RENAME && title === "") ||
           ((modal === MODAL.IMG || modal === MODAL.CODE) && !exportData.data) ||
           (modal === MODAL.SAVEAS && saveAsTitle === "") ||
-          (modal === MODAL.IMPORT_SRC && importSource.src === ""),
+          (modal === MODAL.IMPORT_SRC && importSource.src === "") ||
+          (modal === MODAL.IMPORT_DB && (dbLoading || !connectionParams.host || !connectionParams.database || !connectionParams.user)),
         hidden: modal === MODAL.SHARE,
       }}
       hasCancel={modal !== MODAL.SHARE}

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -88,6 +88,7 @@ export const MODAL = {
   LANGUAGE: 10,
   SHARE: 11,
   CONFIG_CUSTOM_TYPES: 12,
+  IMPORT_DB: 13,
 };
 
 export const STATUS = {

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -290,6 +290,18 @@ const en = {
     type_name_required: "Type name is required",
     database: "Database",
     saved: "Saved",
+    import_from_database: "Import from Database",
+    connect_database: "Connect to Database",
+    host: "Host",
+    port: "Port",
+    database_name: "Database",
+    username: "Username",
+    password: "Password",
+    schema: "Schema",
+    connecting: "Connecting...",
+    connection_failed: "Connection failed",
+    schema_fetched: "Schema fetched successfully",
+    no_backend: "Backend service not configured. Please set VITE_BACKEND_URL.",
   },
 };
 

--- a/src/i18n/locales/zh.js
+++ b/src/i18n/locales/zh.js
@@ -269,6 +269,18 @@ const zh = {
     failed_to_load_diagram: "加载图表失败",
     see_all: "查看全部",
     snap_to_grid: "对齐网格线",
+    import_from_database: "从数据库导入",
+    connect_database: "连接数据库",
+    host: "主机",
+    port: "端口",
+    database_name: "数据库",
+    username: "用户名",
+    password: "密码",
+    schema: "模式",
+    connecting: "连接中...",
+    connection_failed: "连接失败",
+    schema_fetched: "数据库模式获取成功",
+    no_backend: "后端服务未配置，请设置 VITE_BACKEND_URL。",
   },
 };
 

--- a/src/utils/modalData.js
+++ b/src/utils/modalData.js
@@ -25,6 +25,8 @@ export const getModalTitle = (modal) => {
       return i18n.t("language");
     case MODAL.SHARE:
       return i18n.t("share");
+    case MODAL.IMPORT_DB:
+      return i18n.t("import_from_database");
     default:
       return "";
   }
@@ -46,6 +48,7 @@ export const getOkText = (modal) => {
   switch (modal) {
     case MODAL.IMPORT:
     case MODAL.IMPORT_SRC:
+    case MODAL.IMPORT_DB:
       return i18n.t("import");
     case MODAL.CODE:
     case MODAL.IMG:


### PR DESCRIPTION
Add a lightweight Express backend server that connects to PostgreSQL, introspects schema via information_schema/pg_catalog, and generates DDL. The frontend reuses the existing node-sql-parser → fromPostgres() pipeline to convert DDL into diagram tables and relationships.

New files:
- server/: Express backend with POST /api/schema/postgres endpoint
- server/lib/generateDDL.js: 8-layer schema introspection (enums, types, tables, PKs, UKs, FKs, indexes, comments)
- src/api/schema.js: Frontend API client using VITE_BACKEND_URL
- src/components/EditorHeader/Modal/ImportDatabase.jsx: Connection form (host, port, database, user, password, schema, SSL, overwrite option)

Modified:
- MODAL.IMPORT_DB (13) added to constants and modalData
- Modal.jsx integrates IMPORT_DB with async fetch → parse → importSQL
- ControlPanel.jsx adds "Connect to Database" menu entry
- en.js/zh.js: i18n keys for connection UI
- .env.sample: VITE_BACKEND_URL=http://localhost:3001
- compose.yml: drawdb-server service