### PR TITLE
Add table collapse toggle

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -139,6 +139,7 @@ export default function Canvas() {
           table,
           settings.tableWidth,
           settings.showComments,
+          relationships,
         ),
       };
       if (shouldAddElement(tableRect, element)) {

--- a/src/components/EditorCanvas/Relationship.jsx
+++ b/src/components/EditorCanvas/Relationship.jsx
@@ -5,12 +5,13 @@ import { useDiagram, useSettings, useLayout, useSelect } from "../../hooks";
 import { useTranslation } from "react-i18next";
 import { SideSheet } from "@douyinfe/semi-ui";
 import RelationshipInfo from "../EditorSidePanel/RelationshipsTab/RelationshipInfo";
+import { getVisibleFieldIndex, getVisibleFields } from "../../utils/utils";
 
 const labelFontSize = 16;
 
 export default function Relationship({ data }) {
   const { settings } = useSettings();
-  const { tables } = useDiagram();
+  const { tables, relationships } = useDiagram();
   const { layout } = useLayout();
   const { selectedElement, setSelectedElement } = useSelect();
   const { t } = useTranslation();
@@ -22,25 +23,34 @@ export default function Relationship({ data }) {
     if (!startTable || !endTable || startTable.hidden || endTable.hidden)
       return null;
 
+    const startFields = getVisibleFields(startTable, relationships);
+    const endFields = getVisibleFields(endTable, relationships);
+
     return {
-      startFieldIndex: startTable.fields.findIndex(
-        (f) => f.id === data.startFieldId,
+      startFieldIndex: getVisibleFieldIndex(
+        startTable,
+        data.startFieldId,
+        relationships,
       ),
-      endFieldIndex: endTable.fields.findIndex((f) => f.id === data.endFieldId),
+      endFieldIndex: getVisibleFieldIndex(
+        endTable,
+        data.endFieldId,
+        relationships,
+      ),
       startTable: {
         x: startTable.x,
         y: startTable.y,
         comment: startTable.comment,
-        fields: startTable.fields,
+        fields: startFields,
       },
       endTable: {
         x: endTable.x,
         y: endTable.y,
         comment: endTable.comment,
-        fields: endTable.fields,
+        fields: endFields,
       },
     };
-  }, [tables, data]);
+  }, [tables, relationships, data]);
 
   const pathRef = useRef();
   const labelRef = useRef();
@@ -128,7 +138,12 @@ export default function Relationship({ data }) {
       <g className="select-none group" onDoubleClick={edit}>
         {/* invisible wider path for better hover ux */}
         <path
-          d={calcPath(pathValues, settings.tableWidth, 1, settings.showComments)}
+          d={calcPath(
+            pathValues,
+            settings.tableWidth,
+            1,
+            settings.showComments,
+          )}
           fill="none"
           stroke="transparent"
           strokeWidth={12}
@@ -136,7 +151,12 @@ export default function Relationship({ data }) {
         />
         <path
           ref={pathRef}
-          d={calcPath(pathValues, settings.tableWidth, 1, settings.showComments)}
+          d={calcPath(
+            pathValues,
+            settings.tableWidth,
+            1,
+            settings.showComments,
+          )}
           className="relationship-path"
           fill="none"
           cursor="pointer"

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -1,11 +1,14 @@
 import { useMemo, useState } from "react";
 import {
+  Action,
   Tab,
   ObjectType,
   tableHeaderHeight,
   tableColorStripHeight,
 } from "../../data/constants";
 import {
+  IconChevronDown,
+  IconChevronUp,
   IconEdit,
   IconMore,
   IconMinus,
@@ -15,7 +18,13 @@ import {
   IconUnlock,
 } from "@douyinfe/semi-icons";
 import { Popover, Tag, Button, SideSheet } from "@douyinfe/semi-ui";
-import { useLayout, useSettings, useDiagram, useSelect } from "../../hooks";
+import {
+  useLayout,
+  useSettings,
+  useDiagram,
+  useSelect,
+  useUndoRedo,
+} from "../../hooks";
 import TableInfo from "../EditorSidePanel/TablesTab/TableInfo";
 import { useTranslation } from "react-i18next";
 import { resolveType } from "../../utils/customTypes";
@@ -25,6 +34,8 @@ import {
   getCommentHeight,
   getFieldOffsetY,
   getTableHeight,
+  getVisibleFieldEntries,
+  getVisibleFields,
 } from "../../utils/utils";
 
 export default function Table({
@@ -35,9 +46,10 @@ export default function Table({
   setLinkingLine,
 }) {
   const [hoveredField, setHoveredField] = useState(null);
-  const { database } = useDiagram();
   const { layout } = useLayout();
-  const { deleteTable, deleteField, updateTable } = useDiagram();
+  const { database, relationships, deleteTable, deleteField, updateTable } =
+    useDiagram();
+  const { setUndoStack, setRedoStack } = useUndoRedo();
   const { settings } = useSettings();
   const { t } = useTranslation();
   const {
@@ -56,6 +68,17 @@ export default function Table({
     tableData,
     settings.tableWidth,
     settings.showComments,
+    relationships,
+  );
+
+  const visibleFieldEntries = useMemo(
+    () => getVisibleFieldEntries(tableData, relationships),
+    [tableData, relationships],
+  );
+
+  const visibleFields = useMemo(
+    () => getVisibleFields(tableData, relationships),
+    [tableData, relationships],
   );
 
   const isSelected = useMemo(() => {
@@ -67,6 +90,30 @@ export default function Table({
       )
     );
   }, [selectedElement, tableData, bulkSelectedElements]);
+
+  const toggleTableCollapse = (e) => {
+    e.stopPropagation();
+    if (layout.readOnly) return;
+
+    const collapsed = !tableData.collapsed;
+    setUndoStack((prev) => [
+      ...prev,
+      {
+        action: Action.EDIT,
+        element: ObjectType.TABLE,
+        component: "self",
+        tid: tableData.id,
+        undo: { collapsed: tableData.collapsed },
+        redo: { collapsed },
+        message: t("edit_table", {
+          tableName: tableData.name,
+          extra: "[collapse fields]",
+        }),
+      },
+    ]);
+    setRedoStack([]);
+    updateTable(tableData.id, { collapsed });
+  };
 
   const lockUnlockTable = (e) => {
     const locking = !tableData.locked;
@@ -174,104 +221,133 @@ export default function Table({
               <div className="px-3 overflow-hidden text-ellipsis whitespace-nowrap">
                 {tableData.name}
               </div>
-              <div className="hidden group-hover:block">
-                <div className="flex justify-end items-center mx-2 space-x-1.5">
-                  <Button
-                    icon={tableData.locked ? <IconLock /> : <IconUnlock />}
-                    size="small"
-                    theme="solid"
-                    style={{
-                      backgroundColor: "#2f68adb3",
-                    }}
-                    disabled={layout.readOnly}
-                    onClick={lockUnlockTable}
-                  />
-                  <Button
-                    icon={<IconEdit />}
-                    size="small"
-                    theme="solid"
-                    style={{
-                      backgroundColor: "#2f68adb3",
-                    }}
-                    onClick={openEditor}
-                  />
-                  <Popover
-                    key={tableData.id}
-                    content={
-                      <div className="popover-theme">
-                        <div className="mb-2">
-                          <strong>{t("comment")}:</strong>{" "}
-                          {tableData.comment === "" ? (
-                            t("not_set")
-                          ) : (
-                            <div>{tableData.comment}</div>
-                          )}
-                        </div>
-                        <div>
-                          <strong
-                            className={`${
-                              tableData.indices.length === 0 ? "" : "block"
-                            }`}
-                          >
-                            {t("indices")}:
-                          </strong>{" "}
-                          {tableData.indices.length === 0 ? (
-                            t("not_set")
-                          ) : (
-                            <div>
-                              {tableData.indices.map((index, k) => (
-                                <div
-                                  key={k}
-                                  className={`flex items-center my-1 px-2 py-1 rounded ${
-                                    settings.mode === "light"
-                                      ? "bg-gray-100"
-                                      : "bg-zinc-800"
-                                  }`}
-                                >
-                                  <i className="fa-solid fa-thumbtack me-2 mt-1 text-slate-500"></i>
-                                  <div>
-                                    {index.fields.map((f) => (
-                                      <Tag
-                                        color="blue"
-                                        key={f}
-                                        className="me-1"
-                                      >
-                                        {f}
-                                      </Tag>
-                                    ))}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                        <Button
-                          icon={<IconDeleteStroked />}
-                          type="danger"
-                          block
-                          style={{ marginTop: "8px" }}
-                          onClick={() => deleteTable(tableData.id)}
-                          disabled={layout.readOnly}
-                        >
-                          {t("delete")}
-                        </Button>
-                      </div>
-                    }
-                    position="rightTop"
-                    showArrow
-                    trigger="click"
-                    style={{ width: "200px", wordBreak: "break-word" }}
-                  >
+              <div className="flex items-center mx-2 gap-1.5">
+                <Button
+                  icon={
+                    tableData.collapsed ? (
+                      <IconChevronDown />
+                    ) : (
+                      <IconChevronUp />
+                    )
+                  }
+                  size="small"
+                  theme="solid"
+                  style={{
+                    backgroundColor: "#2f68adb3",
+                  }}
+                  disabled={layout.readOnly}
+                  aria-label={
+                    tableData.collapsed
+                      ? "Expand unlinked fields"
+                      : "Collapse unlinked fields"
+                  }
+                  title={
+                    tableData.collapsed
+                      ? "Expand unlinked fields"
+                      : "Collapse unlinked fields"
+                  }
+                  onClick={toggleTableCollapse}
+                  onPointerDown={(e) => e.stopPropagation()}
+                />
+                <div className="hidden group-hover:block">
+                  <div className="flex justify-end items-center mx-2 space-x-1.5">
                     <Button
-                      icon={<IconMore />}
-                      type="tertiary"
+                      icon={tableData.locked ? <IconLock /> : <IconUnlock />}
                       size="small"
+                      theme="solid"
                       style={{
-                        backgroundColor: "#808080b3",
-                        color: "white",
+                        backgroundColor: "#2f68adb3",
                       }}
+                      disabled={layout.readOnly}
+                      onClick={lockUnlockTable}
                     />
-                  </Popover>
+                    <Button
+                      icon={<IconEdit />}
+                      size="small"
+                      theme="solid"
+                      style={{
+                        backgroundColor: "#2f68adb3",
+                      }}
+                      onClick={openEditor}
+                    />
+                    <Popover
+                      key={tableData.id}
+                      content={
+                        <div className="popover-theme">
+                          <div className="mb-2">
+                            <strong>{t("comment")}:</strong>{" "}
+                            {tableData.comment === "" ? (
+                              t("not_set")
+                            ) : (
+                              <div>{tableData.comment}</div>
+                            )}
+                          </div>
+                          <div>
+                            <strong
+                              className={`${
+                                tableData.indices.length === 0 ? "" : "block"
+                              }`}
+                            >
+                              {t("indices")}:
+                            </strong>{" "}
+                            {tableData.indices.length === 0 ? (
+                              t("not_set")
+                            ) : (
+                              <div>
+                                {tableData.indices.map((index, k) => (
+                                  <div
+                                    key={k}
+                                    className={`flex items-center my-1 px-2 py-1 rounded ${
+                                      settings.mode === "light"
+                                        ? "bg-gray-100"
+                                        : "bg-zinc-800"
+                                    }`}
+                                  >
+                                    <i className="fa-solid fa-thumbtack me-2 mt-1 text-slate-500"></i>
+                                    <div>
+                                      {index.fields.map((f) => (
+                                        <Tag
+                                          color="blue"
+                                          key={f}
+                                          className="me-1"
+                                        >
+                                          {f}
+                                        </Tag>
+                                      ))}
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                          <Button
+                            icon={<IconDeleteStroked />}
+                            type="danger"
+                            block
+                            style={{ marginTop: "8px" }}
+                            onClick={() => deleteTable(tableData.id)}
+                            disabled={layout.readOnly}
+                          >
+                            {t("delete")}
+                          </Button>
+                        </div>
+                      }
+                      position="rightTop"
+                      showArrow
+                      trigger="click"
+                      style={{ width: "200px", wordBreak: "break-word" }}
+                    >
+                      <Button
+                        icon={<IconMore />}
+                        type="tertiary"
+                        size="small"
+                        style={{
+                          backgroundColor: "#808080b3",
+                          color: "white",
+                        }}
+                      />
+                    </Popover>
+                  </div>
                 </div>
               </div>
             </div>
@@ -282,11 +358,11 @@ export default function Table({
             )}
           </div>
 
-          {tableData.fields.map((e, i) => {
+          {visibleFieldEntries.map(({ field: e }, i) => {
             const resolved = resolveType(database, e.type);
             return settings.showFieldSummary ? (
               <Popover
-                key={i}
+                key={e.id ?? i}
                 content={
                   <div className="popover-theme">
                     <div
@@ -388,9 +464,7 @@ export default function Table({
     return (
       <div
         className={`${
-          index === tableData.fields.length - 1
-            ? ""
-            : "border-b border-gray-400"
+          index === visibleFields.length - 1 ? "" : "border-b border-gray-400"
         } group w-full overflow-hidden`}
         onPointerEnter={(e) => {
           if (!e.isPrimary) return;
@@ -431,7 +505,7 @@ export default function Table({
                 const fieldY =
                   tableData.y +
                   getFieldOffsetY(
-                    tableData.fields,
+                    visibleFields,
                     index,
                     settings.tableWidth,
                     settings.showComments,

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -9,7 +9,6 @@ import {
 import {
   IconChevronDown,
   IconChevronUp,
-  IconEdit,
   IconMore,
   IconMinus,
   IconDeleteStroked,
@@ -222,33 +221,6 @@ export default function Table({
                 {tableData.name}
               </div>
               <div className="flex items-center mx-2 gap-1.5">
-                <Button
-                  icon={
-                    tableData.collapsed ? (
-                      <IconChevronDown />
-                    ) : (
-                      <IconChevronUp />
-                    )
-                  }
-                  size="small"
-                  theme="solid"
-                  style={{
-                    backgroundColor: "#2f68adb3",
-                  }}
-                  disabled={layout.readOnly}
-                  aria-label={
-                    tableData.collapsed
-                      ? "Expand unlinked fields"
-                      : "Collapse unlinked fields"
-                  }
-                  title={
-                    tableData.collapsed
-                      ? "Expand unlinked fields"
-                      : "Collapse unlinked fields"
-                  }
-                  onClick={toggleTableCollapse}
-                  onPointerDown={(e) => e.stopPropagation()}
-                />
                 <div className="hidden group-hover:block">
                   <div className="flex justify-end items-center mx-2 space-x-1.5">
                     <Button
@@ -262,13 +234,31 @@ export default function Table({
                       onClick={lockUnlockTable}
                     />
                     <Button
-                      icon={<IconEdit />}
+                      icon={
+                        tableData.collapsed ? (
+                          <IconChevronDown />
+                        ) : (
+                          <IconChevronUp />
+                        )
+                      }
                       size="small"
                       theme="solid"
                       style={{
                         backgroundColor: "#2f68adb3",
                       }}
-                      onClick={openEditor}
+                      disabled={layout.readOnly}
+                      aria-label={
+                        tableData.collapsed
+                          ? "Expand unlinked fields"
+                          : "Collapse unlinked fields"
+                      }
+                      title={
+                        tableData.collapsed
+                          ? "Expand unlinked fields"
+                          : "Collapse unlinked fields"
+                      }
+                      onClick={toggleTableCollapse}
+                      onPointerDown={(e) => e.stopPropagation()}
                     />
                     <Popover
                       key={tableData.id}

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -528,7 +528,12 @@ export default function ControlPanel({ title, setTitle, lastSaved }) {
       minMaxXY.maxY = Math.max(
         minMaxXY.maxY,
         table.y +
-          getTableHeight(table, settings.tableWidth, settings.showComments),
+          getTableHeight(
+            table,
+            settings.tableWidth,
+            settings.showComments,
+            relationships,
+          ),
       );
     });
 

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -42,6 +42,7 @@ export default function DiagramContextProvider({ children }) {
       comment: "",
       indices: [],
       color: defaultBlue,
+      collapsed: false,
     };
     if (data) {
       setTables((prev) => {

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -40,6 +40,7 @@ export const tableSchema = {
     comment: { type: "string" },
     locked: { type: "boolean" },
     hidden: { type: "boolean" },
+    collapsed: { type: "boolean" },
     indices: {
       type: "array",
       items: {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -159,6 +159,48 @@ export function getFieldHeight(field, containerWidth, showComments = true) {
   );
 }
 
+export function isFieldRelatedToTable(
+  tableId,
+  field,
+  fieldIndex,
+  relationships = [],
+) {
+  return relationships.some(
+    (relationship) =>
+      (relationship.startTableId === tableId &&
+        (relationship.startFieldId === field.id ||
+          relationship.startFieldId === fieldIndex)) ||
+      (relationship.endTableId === tableId &&
+        (relationship.endFieldId === field.id ||
+          relationship.endFieldId === fieldIndex)),
+  );
+}
+
+export function getVisibleFieldEntries(table, relationships = []) {
+  const fields = table.fields ?? [];
+
+  return fields.reduce((entries, field, index) => {
+    if (
+      !table.collapsed ||
+      isFieldRelatedToTable(table.id, field, index, relationships)
+    ) {
+      entries.push({ field, originalIndex: index });
+    }
+    return entries;
+  }, []);
+}
+
+export function getVisibleFields(table, relationships = []) {
+  return getVisibleFieldEntries(table, relationships).map(({ field }) => field);
+}
+
+export function getVisibleFieldIndex(table, fieldId, relationships = []) {
+  return getVisibleFieldEntries(table, relationships).findIndex(
+    ({ field, originalIndex }) =>
+      field.id === fieldId || originalIndex === fieldId,
+  );
+}
+
 export function getFieldsTotalHeight(
   fields,
   containerWidth,
@@ -185,9 +227,16 @@ export function getFieldOffsetY(
   return total;
 }
 
-export function getTableHeight(table, width, showComments = true) {
+export function getTableHeight(
+  table,
+  width,
+  showComments = true,
+  relationships = [],
+) {
+  const visibleFields = getVisibleFields(table, relationships);
+
   return (
-    getFieldsTotalHeight(table.fields, width, showComments) +
+    getFieldsTotalHeight(visibleFields, width, showComments) +
     tableHeaderHeight +
     tableColorStripHeight +
     getCommentHeight(table.comment, width, showComments)


### PR DESCRIPTION
## What changed

This PR adds a collapse / expand toggle for tables on the canvas.

When a table is collapsed, only the table header is displayed, making large diagrams easier to inspect. Users can expand the table again to restore the full field list.

## Why

Large diagrams with many tables and attributes can become visually crowded. Collapsing table attributes helps users focus on the high-level database structure and relationships.

## How

- Added a collapsed state for tables
- Added a toggle button in the table header
- Updated the table rendering logic to hide fields when collapsed
- Preserved table relationships while the table is collapsed

## Testing

Manually tested by:

1. Importing a PostgreSQL schema with multiple related tables
2. Collapsing individual tables
3. Verifying that only the table header remains visible
4. Expanding tables again
5. Confirming that fields and relationships are restored correctly

Also ran:

- npm run lint
- npm run build

Related to #1004