### PR TITLE
Fix inline REFERENCES not creating relationships in PostgreSQL import

### DIFF
--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -209,7 +209,7 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
             const endTable = tables.find((t) => t.name === endTableName);
             if (!endTable) return;
 
-            const endField = endTable.fields.findIndex(
+            const endField = endTable.fields.find(
               (f) => f.name === endFieldName,
             );
             if (!endField) return;


### PR DESCRIPTION
## Summary

- `findIndex()` returns `0` (falsy) when the referenced field is the **first column** of the target table
- The guard `if (!endField) return` then silently drops the relationship
- Replace `findIndex` with `find` which returns the field object — falsy only when truly not found

## Reproduction

```sql
CREATE TABLE users (
  id UUID PRIMARY KEY  -- first column → findIndex returns 0 → falsy
);

CREATE TABLE posts (
  id UUID PRIMARY KEY,
  user_id UUID REFERENCES users(id)
);
```

Importing this SQL via **Import from SQL → PostgreSQL** produced no relationship between `posts` and `users`.

## Fix

```js
// Before
const endField = endTable.fields.findIndex((f) => f.name === endFieldName);

// After
const endField = endTable.fields.find((f) => f.name === endFieldName);
```

Note: the explicit `FOREIGN KEY` constraint path (line ~140) already uses `find` correctly — only the inline `REFERENCES` path was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)