### PR TITLE
feat: Set layout via Query Params

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,8 +9,8 @@ import NotFound from "./pages/NotFound";
 
 export default function App() {
   return (
-    <SettingsContextProvider>
-      <BrowserRouter>
+    <BrowserRouter>
+      <SettingsContextProvider>
         <RestoreScroll />
         <Routes>
           <Route path="/" element={<LandingPage />} />
@@ -21,8 +21,8 @@ export default function App() {
           <Route path="/templates" element={<Templates />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
-      </BrowserRouter>
-    </SettingsContextProvider>
+      </SettingsContextProvider>
+    </BrowserRouter>
   );
 }
 

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -10,7 +10,7 @@ import {
   IconEdit,
   IconShareStroked,
 } from "@douyinfe/semi-icons";
-import { Link, useMatch, useNavigate, useParams } from "react-router-dom";
+import { Link, useMatch, useParams } from "react-router-dom";
 import icon from "../../assets/icon_dark_64.png";
 import {
   Button,
@@ -62,6 +62,7 @@ import {
   useAreas,
   useEnums,
   useFullscreen,
+  useNavigateWithParams,
 } from "../../hooks";
 import { enterFullscreen, exitFullscreen } from "../../utils/fullscreen";
 import { dataURItoBlob } from "../../utils/utils";
@@ -132,7 +133,7 @@ export default function ControlPanel({
   const { t, i18n } = useTranslation();
   const { version, gistId, setGistId } = useContext(IdContext);
   const isTemplate = useMatch("/editor/templates/:id");
-  const navigate = useNavigate();
+  const navigate = useNavigateWithParams();
 
   const undo = () => {
     if (undoStack.length === 0) return;

--- a/src/components/EditorHeader/Modal/Modal.jsx
+++ b/src/components/EditorHeader/Modal/Modal.jsx
@@ -10,6 +10,7 @@ import {
   useAreas,
   useDiagram,
   useEnums,
+  useNavigateWithParams,
   useNotes,
   useSettings,
   useTransform,
@@ -32,7 +33,6 @@ import Open from "./Open";
 import Rename from "./Rename";
 import SetTableWidth from "./SetTableWidth";
 import Share from "./Share";
-import { useNavigate } from "react-router-dom";
 import { mergeCustomTypes } from "../../../utils/customTypes";
 
 const extensionToLanguage = {
@@ -78,7 +78,7 @@ export default function Modal({
   const [selectedTemplateId, setSelectedTemplateId] = useState(-1);
   const [selectedDiagramId, setSelectedDiagramId] = useState(0);
   const [saveAsTitle, setSaveAsTitle] = useState(title);
-  const navigate = useNavigate();
+  const navigate = useNavigateWithParams();
 
   const overwriteDiagram = () => {
     setTables(importData.tables);

--- a/src/components/EditorHeader/Modal/Share.jsx
+++ b/src/components/EditorHeader/Modal/Share.jsx
@@ -33,7 +33,6 @@ export default function Share({ title, setModal }) {
     hideHeader: null,
     hideSidebar: null,
     hideToolbar: null,
-    forceReadOnly: null,
   });
 
   const url = useMemo(() => {
@@ -185,11 +184,6 @@ export default function Share({ title, setModal }) {
                       {embedSettings.hideToolbar && (
                         <Tag color="blue" size="small">
                           {t("toolbar")}
-                        </Tag>
-                      )}
-                      {embedSettings.forceReadOnly && (
-                        <Tag color="blue" size="small">
-                          {t("read_only")}
                         </Tag>
                       )}
                     </Space>

--- a/src/components/EditorHeader/Modal/Share.jsx
+++ b/src/components/EditorHeader/Modal/Share.jsx
@@ -1,8 +1,8 @@
-import { Banner, Button, Input, Spin, Toast } from "@douyinfe/semi-ui";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { Banner, Button, Input, Spin, Toast, Collapse, Tag, Space, Radio, RadioGroup, Typography } from "@douyinfe/semi-ui";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IdContext } from "../../Workspace";
-import { IconLink } from "@douyinfe/semi-icons";
+import { IconLink, IconCode } from "@douyinfe/semi-icons";
 import {
   useAreas,
   useDiagram,
@@ -15,6 +15,7 @@ import { databases } from "../../../data/databases";
 import { MODAL } from "../../../data/constants";
 import { create, patch, SHARE_FILENAME } from "../../../api/gists";
 import { getCustomTypes } from "../../../utils/customTypes";
+import { queryConfig } from "../../../utils/queryConfig";
 
 export default function Share({ title, setModal }) {
   const { t } = useTranslation();
@@ -27,7 +28,25 @@ export default function Share({ title, setModal }) {
   const { enums } = useEnums();
   const { transform } = useTransform();
   const [error, setError] = useState(null);
-  const url = window.location.origin + "/editor?shareId=" + gistId;
+  const [embedSettings, setEmbedSettings] = useState({
+    theme: null,
+    hideHeader: null,
+    hideSidebar: null,
+    hideToolbar: null,
+    forceReadOnly: null,
+  });
+
+  const url = useMemo(() => {
+    const baseUrl = window.location.origin + "/editor?shareId=" + gistId;
+    const params = new URLSearchParams();
+    Object.entries(embedSettings).forEach(([key, value]) => {
+      if (value) {
+        params.append(queryConfig[key].key, value);
+      }
+    });
+    const queryString = params.toString();
+    return queryString ? baseUrl + "&" + queryString : baseUrl;
+  }, [gistId, embedSettings]);
 
   const diagramToString = useCallback(() => {
     const allCustomTypes = getCustomTypes();
@@ -135,6 +154,81 @@ export default function Share({ title, setModal }) {
         <>
           <div className="flex gap-3">
             <Input value={url} size="large" readonly />
+          </div>
+          <div className="mt-3">
+            <Collapse>
+              <Collapse.Panel
+                header={
+                  <div className="flex items-center justify-between w-full pr-4">
+                    <Space>
+                      <IconCode />
+                      <Typography.Text strong>
+                        {t("embed_settings")}
+                      </Typography.Text>
+                    </Space>
+                    <Space>
+                      {queryConfig.theme.isValid(embedSettings.theme) && (
+                        <Tag color="blue" size="small">
+                          {t(embedSettings.theme)}
+                        </Tag>
+                      )}
+                      {embedSettings.hideHeader && (
+                        <Tag color="blue" size="small">
+                          {t("header")}
+                        </Tag>
+                      )}
+                      {embedSettings.hideSidebar && (
+                        <Tag color="blue" size="small">
+                          {t("sidebar")}
+                        </Tag>
+                      )}
+                      {embedSettings.hideToolbar && (
+                        <Tag color="blue" size="small">
+                          {t("toolbar")}
+                        </Tag>
+                      )}
+                      {embedSettings.forceReadOnly && (
+                        <Tag color="blue" size="small">
+                          {t("read_only")}
+                        </Tag>
+                      )}
+                    </Space>
+                  </div>
+                }
+                itemKey="embed-settings"
+              >
+                <div className="space-y-4 py-2">
+                  {Object.entries(queryConfig).map(([key, config]) => (
+                    <div
+                      key={key}
+                      className="flex items-center justify-between gap-4"
+                    >
+                      <Typography.Text>{t(config.label)}</Typography.Text>
+                      <RadioGroup
+                        type="button"
+                        name={config.key}
+                        value={embedSettings[key]}
+                        onChange={(e) =>
+                          setEmbedSettings((prev) => ({
+                            ...prev,
+                            [key]: e.target.value,
+                          }))
+                        }
+                      >
+                        {config.options.map((option) => (
+                          <Radio
+                            key={String(option.value)}
+                            value={option.value}
+                          >
+                            {t(option.label)}
+                          </Radio>
+                        ))}
+                      </RadioGroup>
+                    </div>
+                  ))}
+                </div>
+              </Collapse.Panel>
+            </Collapse>
           </div>
           <div className="text-xs mt-2">{t("share_info")}</div>
           <div className="flex gap-2 mt-3">

--- a/src/components/Workspace.jsx
+++ b/src/components/Workspace.jsx
@@ -16,6 +16,7 @@ import {
   useTypes,
   useSaveState,
   useEnums,
+  useNavigateWithParams,
 } from "../hooks";
 import FloatingControls from "./FloatingControls";
 import { Button, Modal, Tag } from "@douyinfe/semi-ui";
@@ -25,7 +26,6 @@ import { databases } from "../data/databases";
 import { isRtl } from "../i18n/utils/rtl";
 import {
   useMatch,
-  useNavigate,
   useParams,
   useSearchParams,
 } from "react-router-dom";
@@ -77,7 +77,7 @@ export default function WorkSpace() {
   const isDiagram = useMatch("/editor/diagrams/:id");
   const isTemplate = useMatch("/editor/templates/:id");
 
-  const navigate = useNavigate();
+  const navigate = useNavigateWithParams();
 
   const handleResize = (e) => {
     if (!resize) return;

--- a/src/context/LayoutContext.jsx
+++ b/src/context/LayoutContext.jsx
@@ -1,19 +1,36 @@
 import { createContext, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 export const LayoutContext = createContext(null);
 
+const defaultLayout = {
+  header: true,
+  sidebar: true,
+  issues: true,
+  toolbar: true,
+  dbmlEditor: false,
+  readOnly: false,
+};
+
 export default function LayoutContextProvider({ children }) {
+  const [searchParams] = useSearchParams();
+
   const [layout, setLayout] = useState({
-    header: true,
-    sidebar: true,
-    issues: true,
-    toolbar: true,
-    dbmlEditor: false,
-    readOnly: false,
+    ...defaultLayout,
+    header: searchParams.get("hideHeader") !== "true",
+    sidebar: searchParams.get("hideSidebar") !== "true",
+    toolbar: searchParams.get("hideToolbar") !== "true",
   });
 
+  const forceReadOnly = searchParams.get("forceReadOnly") === "true";
+
   return (
-    <LayoutContext.Provider value={{ layout, setLayout }}>
+    <LayoutContext.Provider
+      value={{
+        layout: forceReadOnly ? { ...layout, readOnly: true } : layout,
+        setLayout,
+      }}
+    >
       {children}
     </LayoutContext.Provider>
   );

--- a/src/context/LayoutContext.jsx
+++ b/src/context/LayoutContext.jsx
@@ -15,19 +15,40 @@ const defaultLayout = {
 export default function LayoutContextProvider({ children }) {
   const [searchParams] = useSearchParams();
 
+  const hideHeaderParam = searchParams.get("hideHeader");
+  const hideSidebarParam = searchParams.get("hideSidebar");
+  const hideToolbarParam = searchParams.get("hideToolbar");
+  const isForceReadOnly = searchParams.get("forceReadOnly") === "true";
+
   const [layout, setLayout] = useState({
     ...defaultLayout,
-    header: searchParams.get("hideHeader") !== "true",
-    sidebar: searchParams.get("hideSidebar") !== "true",
-    toolbar: searchParams.get("hideToolbar") !== "true",
+    header:
+      hideHeaderParam === "true" || hideHeaderParam === "force"
+        ? false
+        : defaultLayout.header,
+    sidebar:
+      hideSidebarParam === "true" || hideSidebarParam === "force"
+        ? false
+        : defaultLayout.sidebar,
+    toolbar:
+      hideToolbarParam === "true" || hideToolbarParam === "force"
+        ? false
+        : defaultLayout.toolbar,
+    readOnly: isForceReadOnly || defaultLayout.readOnly,
   });
 
-  const forceReadOnly = searchParams.get("forceReadOnly") === "true";
+  const effectiveLayout = {
+    ...layout,
+    header: hideHeaderParam === "force" ? false : layout.header,
+    sidebar: hideSidebarParam === "force" ? false : layout.sidebar,
+    toolbar: hideToolbarParam === "force" ? false : layout.toolbar,
+    readOnly: isForceReadOnly ? true : layout.readOnly,
+  };
 
   return (
     <LayoutContext.Provider
       value={{
-        layout: forceReadOnly ? { ...layout, readOnly: true } : layout,
+        layout: effectiveLayout,
         setLayout,
       }}
     >

--- a/src/context/LayoutContext.jsx
+++ b/src/context/LayoutContext.jsx
@@ -19,7 +19,6 @@ export default function LayoutContextProvider({ children }) {
   const hideHeaderParam = searchParams.get(queryConfig.hideHeader.key);
   const hideSidebarParam = searchParams.get(queryConfig.hideSidebar.key);
   const hideToolbarParam = searchParams.get(queryConfig.hideToolbar.key);
-  const forceReadOnlyParam = searchParams.get(queryConfig.forceReadOnly.key);
 
   const [layout, setLayout] = useState({
     ...defaultLayout,
@@ -32,9 +31,6 @@ export default function LayoutContextProvider({ children }) {
     toolbar: queryConfig.hideToolbar.isActive(hideToolbarParam)
       ? false
       : defaultLayout.toolbar,
-    readOnly: queryConfig.forceReadOnly.isActive(forceReadOnlyParam)
-      ? true
-      : defaultLayout.readOnly,
   });
 
   const effectiveLayout = {
@@ -48,9 +44,6 @@ export default function LayoutContextProvider({ children }) {
     toolbar: queryConfig.hideToolbar.isForced(hideToolbarParam)
       ? false
       : layout.toolbar,
-    readOnly: queryConfig.forceReadOnly.isForced(forceReadOnlyParam)
-      ? true
-      : layout.readOnly,
   };
 
   return (

--- a/src/context/LayoutContext.jsx
+++ b/src/context/LayoutContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { queryConfig } from "../utils/queryConfig";
 
 export const LayoutContext = createContext(null);
 
@@ -15,34 +16,41 @@ const defaultLayout = {
 export default function LayoutContextProvider({ children }) {
   const [searchParams] = useSearchParams();
 
-  const hideHeaderParam = searchParams.get("hideHeader");
-  const hideSidebarParam = searchParams.get("hideSidebar");
-  const hideToolbarParam = searchParams.get("hideToolbar");
-  const isForceReadOnly = searchParams.get("forceReadOnly") === "true";
+  const hideHeaderParam = searchParams.get(queryConfig.hideHeader.key);
+  const hideSidebarParam = searchParams.get(queryConfig.hideSidebar.key);
+  const hideToolbarParam = searchParams.get(queryConfig.hideToolbar.key);
+  const forceReadOnlyParam = searchParams.get(queryConfig.forceReadOnly.key);
 
   const [layout, setLayout] = useState({
     ...defaultLayout,
-    header:
-      hideHeaderParam === "true" || hideHeaderParam === "force"
-        ? false
-        : defaultLayout.header,
-    sidebar:
-      hideSidebarParam === "true" || hideSidebarParam === "force"
-        ? false
-        : defaultLayout.sidebar,
-    toolbar:
-      hideToolbarParam === "true" || hideToolbarParam === "force"
-        ? false
-        : defaultLayout.toolbar,
-    readOnly: isForceReadOnly || defaultLayout.readOnly,
+    header: queryConfig.hideHeader.isActive(hideHeaderParam)
+      ? false
+      : defaultLayout.header,
+    sidebar: queryConfig.hideSidebar.isActive(hideSidebarParam)
+      ? false
+      : defaultLayout.sidebar,
+    toolbar: queryConfig.hideToolbar.isActive(hideToolbarParam)
+      ? false
+      : defaultLayout.toolbar,
+    readOnly: queryConfig.forceReadOnly.isActive(forceReadOnlyParam)
+      ? true
+      : defaultLayout.readOnly,
   });
 
   const effectiveLayout = {
     ...layout,
-    header: hideHeaderParam === "force" ? false : layout.header,
-    sidebar: hideSidebarParam === "force" ? false : layout.sidebar,
-    toolbar: hideToolbarParam === "force" ? false : layout.toolbar,
-    readOnly: isForceReadOnly ? true : layout.readOnly,
+    header: queryConfig.hideHeader.isForced(hideHeaderParam)
+      ? false
+      : layout.header,
+    sidebar: queryConfig.hideSidebar.isForced(hideSidebarParam)
+      ? false
+      : layout.sidebar,
+    toolbar: queryConfig.hideToolbar.isForced(hideToolbarParam)
+      ? false
+      : layout.toolbar,
+    readOnly: queryConfig.forceReadOnly.isForced(forceReadOnlyParam)
+      ? true
+      : layout.readOnly,
   };
 
   return (

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { tableWidth } from "../data/constants";
 
 const defaultSettings = {
@@ -19,14 +20,21 @@ const defaultSettings = {
 export const SettingsContext = createContext(defaultSettings);
 
 export default function SettingsContextProvider({ children }) {
-  const [settings, setSettings] = useState(defaultSettings);
+  const [searchParams] = useSearchParams();
 
-  useEffect(() => {
-    const settings = localStorage.getItem("settings");
-    if (settings) {
-      setSettings({ ...defaultSettings, ...JSON.parse(settings) });
+  const [settings, setSettings] = useState(() => {
+    const savedSettings = localStorage.getItem("settings");
+    let baseSettings = savedSettings
+      ? { ...defaultSettings, ...JSON.parse(savedSettings) }
+      : defaultSettings;
+
+    const theme = searchParams.get("theme");
+    if (theme === "light" || theme === "dark") {
+      baseSettings = { ...baseSettings, mode: theme };
     }
-  }, []);
+
+    return baseSettings;
+  });
 
   useEffect(() => {
     document.body.setAttribute("theme-mode", settings.mode);

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { tableWidth } from "../data/constants";
+import { queryConfig } from "../utils/queryConfig";
 
 const defaultSettings = {
   strictMode: false,
@@ -28,8 +29,8 @@ export default function SettingsContextProvider({ children }) {
       ? { ...defaultSettings, ...JSON.parse(savedSettings) }
       : defaultSettings;
 
-    const theme = searchParams.get("theme");
-    if (theme === "light" || theme === "dark") {
+    const theme = searchParams.get(queryConfig.theme.key);
+    if (queryConfig.theme.isValid(theme)) {
       baseSettings = { ...baseSettings, mode: theme };
     }
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -12,3 +12,4 @@ export { default as useTypes } from "./useTypes";
 export { default as useUndoRedo } from "./useUndoRedo";
 export { default as useEnums } from "./useEnums";
 export { default as useThemedPage } from "./useThemedPage";
+export { default as useNavigateWithParams } from "./useNavigateWithParams";

--- a/src/hooks/useNavigateWithParams.js
+++ b/src/hooks/useNavigateWithParams.js
@@ -1,0 +1,13 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function useNavigateWithParams() {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (to, options = {}) => {
+      navigate(to + window.location.search, options);
+    },
+    [navigate],
+  );
+}

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -296,8 +296,7 @@ const en = {
     embed_settings: "Embed settings",
     default: "Default",
     hide: "Hide",
-    force_hide: "Force hide",
-    force_read_only: "Force read only",
+    force_hide: "Force hide"
   },
 };
 

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -48,6 +48,7 @@ const en = {
     view: "View",
     header: "Menubar",
     sidebar: "Sidebar",
+    toolbar: "Toolbar",
     issues: "Issues",
     presentation_mode: "Presentation mode",
     strict_mode: "Strict mode",
@@ -291,7 +292,12 @@ const en = {
     database: "Database",
     saved: "Saved",
     structure: "Structure",
-    code: "Code"
+    code: "Code",
+    embed_settings: "Embed settings",
+    default: "Default",
+    hide: "Hide",
+    force_hide: "Force hide",
+    force_read_only: "Force read only",
   },
 };
 

--- a/src/utils/queryConfig.js
+++ b/src/utils/queryConfig.js
@@ -1,0 +1,26 @@
+export const queryConfig = {
+  theme: {
+    key: "theme",
+    isValid: (val) => ["light", "dark"].includes(val),
+  },
+  hideHeader: {
+    key: "hideHeader",
+    isActive: (val) => val === "true" || val === "force",
+    isForced: (val) => val === "force",
+  },
+  hideSidebar: {
+    key: "hideSidebar",
+    isActive: (val) => val === "true" || val === "force",
+    isForced: (val) => val === "force",
+  },
+  hideToolbar: {
+    key: "hideToolbar",
+    isActive: (val) => val === "true" || val === "force",
+    isForced: (val) => val === "force",
+  },
+  forceReadOnly: {
+    key: "forceReadOnly",
+    isActive: (val) => val === "true",
+    isForced: (val) => val === "true",
+  },
+};

--- a/src/utils/queryConfig.js
+++ b/src/utils/queryConfig.js
@@ -1,25 +1,54 @@
 export const queryConfig = {
   theme: {
     key: "theme",
+    label: "theme",
+    options: [
+      { label: "default", value: null },
+      { label: "light", value: "light" },
+      { label: "dark", value: "dark" },
+    ],
     isValid: (val) => ["light", "dark"].includes(val),
   },
   hideHeader: {
     key: "hideHeader",
+    label: "header",
+    options: [
+      { label: "default", value: null },
+      { label: "hide", value: "true" },
+      { label: "force_hide", value: "force" },
+    ],
     isActive: (val) => val === "true" || val === "force",
     isForced: (val) => val === "force",
   },
   hideSidebar: {
     key: "hideSidebar",
+    label: "sidebar",
+    options: [
+      { label: "default", value: null },
+      { label: "hide", value: "true" },
+      { label: "force_hide", value: "force" },
+    ],
     isActive: (val) => val === "true" || val === "force",
     isForced: (val) => val === "force",
   },
   hideToolbar: {
     key: "hideToolbar",
+    label: "toolbar",
+    options: [
+      { label: "default", value: null },
+      { label: "hide", value: "true" },
+      { label: "force_hide", value: "force" },
+    ],
     isActive: (val) => val === "true" || val === "force",
     isForced: (val) => val === "force",
   },
   forceReadOnly: {
     key: "forceReadOnly",
+    label: "read_only",
+    options: [
+      { label: "default", value: null },
+      { label: "force_read_only", value: "true" },
+    ],
     isActive: (val) => val === "true",
     isForced: (val) => val === "true",
   },

--- a/src/utils/queryConfig.js
+++ b/src/utils/queryConfig.js
@@ -42,14 +42,4 @@ export const queryConfig = {
     isActive: (val) => val === "true" || val === "force",
     isForced: (val) => val === "force",
   },
-  forceReadOnly: {
-    key: "forceReadOnly",
-    label: "read_only",
-    options: [
-      { label: "default", value: null },
-      { label: "force_read_only", value: "true" },
-    ],
-    isActive: (val) => val === "true",
-    isForced: (val) => val === "true",
-  },
 };


### PR DESCRIPTION
## Description
- Adds query params allowing you to hide (or force hide) the menubar/sidebar/toolbar and set the default theme.
- When a layout element is force-hidden (e.g `?hideSidebar=force`) it will stay hidden even when e.g exiting full-screen tries to bring it back
- When a layout element is just hidden (e.g `?hideSidebar=true`) it would be possible to show this element again. Refreshing the page would hide the element once again (assuming it is still in the url)

## Notes
- I had to swap the order of the `<BrowserRouter>` and `<SettingsContextProvider>` to be able to use `useSearchParams` in the SettingsContext. I'm not sure if that brings any unwanted side-effects but I haven't encountered any during testing.
- I swapped out all `useNavigate` calls with `useNavigateWithParams` because the navigations would lose the query parameters previously.
- I had wanted to add a couple more query parameters (e.g fitWindow, hideGrid, hideCardinality, showComments, etc) but didn't want to make this PR massive, and also wasn't sure where the best place to put each one would be. For example fitWindow is in the ControlPanel component, so I thought to move fitWindow to a useFitWindow hook, but then I still wasn't sure where a good place to read that query param would be.

## Share Dialog
- I'm not a frontend designer by any means, but I tried my best to imitate the mock-up.
- Currently there is no distinction for what value has been selected in the 'preview' pills. e.g `Hide` and `Force Hide` for Sidebar would both just show up as a `Sidebar` pill. Maybe they could have differing colors?
<img width="593" height="484" alt="image" src="https://github.com/user-attachments/assets/7be5447c-8249-4a75-af19-dba757049aae" />


Related discussion: https://discord.com/channels/1196658537208758412/1226277731835052133/1507952878289944716