### PR TITLE
Update Nginx base image to stable-alpine3.23 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
 # Stage 2: Setup the Nginx Server to serve the app
-FROM docker.io/library/nginx:stable-alpine3.17 AS production
+FROM docker.io/library/nginx:stable-alpine3.23 AS production
 COPY --from=build /app/dist /usr/share/nginx/html
 RUN echo 'server { listen 80; server_name _; root /usr/share/nginx/html;  location / { try_files $uri /index.html; } }' > /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
I've noticed that they was toomany CVE vulnerabilities into this version of nginx docker image : nginx:stable-alpine3.17 (cf. screenshot below).

<img width="1049" height="295" alt="image" src="https://github.com/user-attachments/assets/c9472611-2afd-4dd8-9a7d-d42fd9d153a0" />

So I updated the version in the Dockerfile to nginx:stable-alpine3.23 in order to reduce vulnerabilities and achieve this result : 

<img width="1049" height="295" alt="image" src="https://github.com/user-attachments/assets/9969e90e-f144-4240-8d92-475044431e1a" />
