### PR TITLE
Upgrade react-tweet to 3.3.1 to fix entities error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "react-hotkeys-hook": "^4.4.1",
         "react-i18next": "^14.1.1",
         "react-router-dom": "^6.30.3",
-        "react-tweet": "^3.2.1",
+        "react-tweet": "^3.3.1",
         "usehooks-ts": "^3.1.0"
       },
       "devDependencies": {
@@ -7621,9 +7621,9 @@
       }
     },
     "node_modules/react-tweet": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.2.2.tgz",
-      "integrity": "sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.3.1.tgz",
+      "integrity": "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "react-dom": "^18.2.0",
         "react-hotkeys-hook": "^4.4.1",
         "react-i18next": "^14.1.1",
-        "react-router-dom": "^6.30.3",
         "react-tweet": "^3.3.1",
         "react-router-dom": "^6.30.4",
         "react-tweet": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-dom": "^18.2.0",
     "react-hotkeys-hook": "^4.4.1",
     "react-i18next": "^14.1.1",
-    "react-router-dom": "^6.30.3",
     "react-tweet": "^3.3.1",
     "react-router-dom": "^6.30.4",
     "react-tweet": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-hotkeys-hook": "^4.4.1",
     "react-i18next": "^14.1.1",
     "react-router-dom": "^6.30.3",
-    "react-tweet": "^3.2.1",
+    "react-tweet": "^3.3.1",
     "usehooks-ts": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Upgrades `react-tweet` from `3.2.2` to `3.3.1`
- Fixes `Uncaught TypeError: entities is not iterable` in the landing page tweet section

## Cause
The X syndication API sometimes omits entity arrays (`hashtags`, `urls`, etc.). Older `react-tweet` versions tried to iterate over `undefined`, which crashes the landing page.

Upstream fix: https://github.com/vercel/react-tweet/issues/218 (released in 3.3.1)

## Test plan
- [ ] `npm install`
- [ ] `npm run dev`
- [ ] Open the landing page and confirm tweets under "What the internet says about us" render without console errors