### PR TITLE
Fix presentation mode ESC not restoring UI panels

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Slot, useExtensions } from "../../context/ExtensionsContext";
 import { createPortal } from "react-dom";
 import {
@@ -814,6 +814,11 @@ export default function ControlPanel({
   const open = () => setModal(MODAL.OPEN);
   const saveDiagramAs = () => setModal(MODAL.SAVEAS);
   const fullscreen = useFullscreen();
+
+  useEffect(() => {
+    if (!fullscreen)
+      setLayout((p) => ({ ...p, header: true, sidebar: true, toolbar: true }));
+  }, [fullscreen, setLayout]);
 
   const menu = {
     file: {


### PR DESCRIPTION
## Summary
- Fix presentation mode not restoring UI panels (header, sidebar, toolbar) when exiting fullscreen via ESC

## Problem
Presentation mode hides UI panels (`header`, `sidebar`, `toolbar`) before entering browser fullscreen. Pressing ESC triggers the browser's native fullscreen exit but doesn't restore the application-level layout state, leaving the editor with no visible controls.

## Solution
Add a `useEffect` in `ControlPanel` that restores layout when `fullscreen` becomes `false`.