### PR TITLE
feat: Miro-like pan and zoom

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -79,6 +79,7 @@ export default function Canvas() {
   });
   const { emitAwareness } = useCollab();
   const lastLinkingRef = useRef(false);
+  const rightClickPanned = useRef(false);
 
   useEffect(() => {
     if (linking) {
@@ -472,6 +473,7 @@ export default function Canvas() {
       }
       pointer.setStyle("crosshair");
     } else if (isMouseMiddleButton || isMouseRightButton) {
+      if (isMouseRightButton) rightClickPanned.current = false;
       setPanning({
         isPanning: true,
         panStart: transform.pan,
@@ -558,6 +560,7 @@ export default function Canvas() {
 
     if (panning.isPanning && didPan()) {
       setSaveState(State.SAVING);
+      if (e.button === 2) rightClickPanned.current = true;
     }
     setPanning((old) => ({ ...old, isPanning: false }));
     pointer.setStyle("default");
@@ -718,7 +721,12 @@ export default function Canvas() {
           onPointerMove={handlePointerMove}
           onPointerDown={handlePointerDown}
           onPointerUp={handlePointerUp}
-          onContextMenu={(e) => e.preventDefault()}
+          onContextMenu={(e) => {
+            if (rightClickPanned.current) {
+              e.preventDefault();
+              rightClickPanned.current = false;
+            }
+          }}
           className="absolute w-full h-full touch-none"
           viewBox={`${viewBox.left} ${viewBox.top} ${viewBox.width} ${viewBox.height}`}
         >

--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -455,6 +455,7 @@ export default function Canvas() {
 
     const isMouseLeftButton = e.button === 0;
     const isMouseMiddleButton = e.button === 1;
+    const isMouseRightButton = e.button === 2;
 
     if (isMouseLeftButton) {
       setBulkSelectRect({
@@ -470,7 +471,7 @@ export default function Canvas() {
         handlePointerDownOnElement(e, elementPointerDown);
       }
       pointer.setStyle("crosshair");
-    } else if (isMouseMiddleButton) {
+    } else if (isMouseMiddleButton || isMouseRightButton) {
       setPanning({
         isPanning: true,
         panStart: transform.pan,
@@ -726,6 +727,7 @@ export default function Canvas() {
           onPointerMove={handlePointerMove}
           onPointerDown={handlePointerDown}
           onPointerUp={handlePointerUp}
+          onContextMenu={(e) => e.preventDefault()}
           className="absolute w-full h-full touch-none"
           viewBox={`${viewBox.left} ${viewBox.top} ${viewBox.width} ${viewBox.height}`}
         >

--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -671,9 +671,16 @@ export default function Canvas() {
     (e) => {
       e.preventDefault();
 
-      if (e.ctrlKey || e.metaKey) {
-        // How "eager" the viewport is to
-        // center the cursor's coordinates
+      if (e.shiftKey) {
+        setTransform((prev) => ({
+          ...prev,
+          pan: {
+            ...prev.pan,
+            x: prev.pan.x + e.deltaY / prev.zoom,
+          },
+        }));
+      } else {
+        // Default and Ctrl/Meta: zoom centered on cursor
         const eagernessFactor = 0.05;
         setTransform((prev) => ({
           pan: {
@@ -689,22 +696,6 @@ export default function Canvas() {
                 Math.sign(e.deltaY),
           },
           zoom: e.deltaY <= 0 ? prev.zoom * 1.05 : prev.zoom / 1.05,
-        }));
-      } else if (e.shiftKey) {
-        setTransform((prev) => ({
-          ...prev,
-          pan: {
-            ...prev.pan,
-            x: prev.pan.x + e.deltaY / prev.zoom,
-          },
-        }));
-      } else {
-        setTransform((prev) => ({
-          ...prev,
-          pan: {
-            x: prev.pan.x + e.deltaX / prev.zoom,
-            y: prev.pan.y + e.deltaY / prev.zoom,
-          },
         }));
       }
     },


### PR DESCRIPTION
## Summary

Adds Miro-style canvas navigation:

- **Right-mouse drag** pans the canvas (cursor shows `grabbing`). The browser context menu is suppressed on the canvas to prevent interference.
- **Scroll wheel** zooms in/out centered on the cursor position. Scroll up = zoom in, scroll down = zoom out.
- **Shift + scroll** pans horizontally (unchanged).
- **Middle-mouse drag** pans the canvas (unchanged).

This matches the navigation model used in Figma, Miro, and similar design tools, making the canvas feel immediately familiar.

## Changes

- `src/components/EditorCanvas/Canvas.jsx`
  - `handlePointerDown`: fold `e.button === 2` (right mouse) into the existing middle-button pan branch
  - SVG element: add `onContextMenu={(e) => e.preventDefault()}` to suppress browser context menu on right-click
  - `wheel` handler: make plain scroll zoom (cursor-centered), keeping `Shift+scroll` as horizontal pan

## Behaviour table

| Interaction | Result |
|---|---|
| Scroll wheel up | Zoom in (centered on cursor) |
| Scroll wheel down | Zoom out (centered on cursor) |
| Shift + scroll | Pan horizontally |
| Right-mouse drag | Pan canvas |
| Middle-mouse drag | Pan canvas (unchanged) |
| Left-click / drag | Select / move elements (unchanged) |

## Test plan

- [ ] Scroll up zooms in toward cursor, scroll down zooms out
- [ ] Shift+scroll pans horizontally
- [ ] Right-click drag pans the canvas
- [ ] Right-click on canvas does not show browser context menu
- [ ] Middle-mouse drag still pans
- [ ] Left-click selection and element dragging unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)