### PR TITLE
fix: resolve DBML with field length definitions triggers SQL generation errors

### DIFF
--- a/src/utils/exportSQL/generic.js
+++ b/src/utils/exportSQL/generic.js
@@ -207,7 +207,10 @@ export function jsonToMySQL(obj) {
               }${
                 field.check === "" ||
                 !dbToTypes[obj.database][field.type].hasCheck
-                  ? !Object.keys(defaultTypes).includes(field.type)
+                  ? !Object.keys(defaultTypes).includes(field.type) &&
+                    obj.types.find(
+                      (t) => t.name === field.type.toLowerCase(),
+                    )
                     ? ` CHECK(\n\t\tJSON_SCHEMA_VALID("${generateSchema(
                         obj.types.find(
                           (t) => t.name === field.type.toLowerCase(),
@@ -458,7 +461,10 @@ export function jsonToMariaDB(obj) {
               }${
                 field.check === "" ||
                 !dbToTypes[obj.database][field.type].hasCheck
-                  ? !Object.keys(defaultTypes).includes(field.type)
+                  ? !Object.keys(defaultTypes).includes(field.type) &&
+                    obj.types.find(
+                      (t) => t.name === field.type.toLowerCase(),
+                    )
                     ? ` CHECK(\n\t\tJSON_SCHEMA_VALID('${generateSchema(
                         obj.types.find(
                           (t) => t.name === field.type.toLowerCase(),

--- a/src/utils/importFrom/dbml.js
+++ b/src/utils/importFrom/dbml.js
@@ -28,7 +28,9 @@ export function fromDBML(src) {
 
         field.id = nanoid();
         field.name = column.name;
+        // type_name: 纯类型名（如 "VARCHAR"），args: 参数字符串（如 "50"）
         field.type = column.type.type_name.toUpperCase();
+        field.size = column.type.args ?? "";
         field.default = column.dbdefault?.value ?? "";
         field.check = "";
         field.primary = !!column.pk;


### PR DESCRIPTION
- DBML import now separates type_name and args into field.type and field.size
- jsonToMySQL/jsonToMariaDB: guard generateSchema against undefined types when obj.types is empty or the custom type is not found

Fixes [[BUG] DBML with field length definitions triggers SQL generation errors](https://github.com/drawdb-io/drawdb/issues/1051)

I’m Chinese and my English isn’t very good either, so I rely on AI translation.
Could the administrator please take a look? Feel free to point out any issues or suggestions, and I will fully cooperate.