### PR TITLE
Fix/issue 1051 export sql crash varchar json

### DIFF
--- a/src/utils/exportSQL/generic.js
+++ b/src/utils/exportSQL/generic.js
@@ -207,7 +207,10 @@ export function jsonToMySQL(obj) {
               }${
                 field.check === "" ||
                 !dbToTypes[obj.database][field.type].hasCheck
-                  ? !Object.keys(defaultTypes).includes(field.type)
+                  ? !Object.keys(defaultTypes).includes(field.type) &&
+                    obj.types.find(
+                      (t) => t.name === field.type.toLowerCase(),
+                    )
                     ? ` CHECK(\n\t\tJSON_SCHEMA_VALID("${generateSchema(
                         obj.types.find(
                           (t) => t.name === field.type.toLowerCase(),
@@ -458,7 +461,10 @@ export function jsonToMariaDB(obj) {
               }${
                 field.check === "" ||
                 !dbToTypes[obj.database][field.type].hasCheck
-                  ? !Object.keys(defaultTypes).includes(field.type)
+                  ? !Object.keys(defaultTypes).includes(field.type) &&
+                    obj.types.find(
+                      (t) => t.name === field.type.toLowerCase(),
+                    )
                     ? ` CHECK(\n\t\tJSON_SCHEMA_VALID('${generateSchema(
                         obj.types.find(
                           (t) => t.name === field.type.toLowerCase(),

--- a/src/utils/importFrom/dbml.js
+++ b/src/utils/importFrom/dbml.js
@@ -28,7 +28,11 @@ export function fromDBML(src) {
 
         field.id = nanoid();
         field.name = column.name;
-        field.type = column.type.type_name.toUpperCase();
+        // type_name 带括号（如 "varchar(50)"），需剥离；args 为参数字符串（如 "50"）
+        const rawType = column.type.type_name.toUpperCase();
+        const parenIdx = rawType.indexOf("(");
+        field.type = parenIdx !== -1 ? rawType.substring(0, parenIdx) : rawType;
+        field.size = column.type.args ?? "";
         field.default = column.dbdefault?.value ?? "";
         field.check = "";
         field.primary = !!column.pk;

--- a/src/utils/importFrom/dbml.js
+++ b/src/utils/importFrom/dbml.js
@@ -28,10 +28,11 @@ export function fromDBML(src) {
 
         field.id = nanoid();
         field.name = column.name;
-        // type_name 带括号（如 "varchar(50)"），需剥离；args 为参数字符串（如 "50"）
-        const rawType = column.type.type_name.toUpperCase();
-        const parenIdx = rawType.indexOf("(");
-        field.type = parenIdx !== -1 ? rawType.substring(0, parenIdx) : rawType;
+        // type_name includes parentheses (e.g. "varchar(50)"), args is the parameter string (e.g. "50").
+        // Separate them into raw type name and size for drawdb's internal format.
+        const rawTypeName = column.type.type_name.toUpperCase();
+        const parenIdx = rawTypeName.indexOf("(");
+        field.type = parenIdx !== -1 ? rawTypeName.substring(0, parenIdx) : rawTypeName;
         field.size = column.type.args ?? "";
         field.default = column.dbdefault?.value ?? "";
         field.check = "";


### PR DESCRIPTION
- DBML import now separates type_name and args into field.type and field.size
- jsonToMySQL/jsonToMariaDB: guard generateSchema against undefined types when obj.types is empty or the custom type is not found

Fixes [[BUG] DBML with field length definitions triggers SQL generation errors](https://github.com/drawdb-io/drawdb/issues/1051)

I’m Chinese and my English isn’t very good either, so I rely on AI translation.
Could the administrator please take a look? Feel free to point out any issues or suggestions, and I will fully cooperate.