### PR TITLE
Add canvas pan mode with hand tool toggle and shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1743,9 +1743,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6450,9 +6450,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1743,9 +1743,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6450,9 +6450,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/src/components/EditorCanvas/Area.jsx
+++ b/src/components/EditorCanvas/Area.jsx
@@ -161,7 +161,7 @@ export default function Area({
         onPointerDown={onPointerDown}
       >
         <div
-          className={`w-full h-full p-2 rounded cursor-move border-2 ${
+          className={`w-full h-full p-2 rounded border-2 ${layout.panMode ? "cursor-grab" : "cursor-move"} ${
             isHovered
               ? "border-dashed border-blue-500"
               : isSelected
@@ -215,7 +215,7 @@ export default function Area({
           </div>
         </div>
       </foreignObject>
-      {isHovered && (
+      {isHovered && !layout.panMode && (
         <>
           <circle
             cx={data.x}

--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -41,7 +41,7 @@ export default function Canvas() {
   const canvasRef = useRef(null);
   const canvasContextValue = useCanvas();
   const {
-    canvas: { viewBox },
+    canvas: { viewBox, screenSize },
     pointer,
   } = canvasContextValue;
 
@@ -307,50 +307,28 @@ export default function Canvas() {
     return { x, y };
   };
 
-  /**
-   * @param {PointerEvent} e
-   */
-  const handlePointerMove = (e) => {
-    if (selectedElement.open && !layout.sidebar) return;
-
-    if (!e.isPrimary) return;
-
-    if (panning.isPanning) {
-      setTransform((prev) => ({
-        ...prev,
-        pan: {
-          x:
-            panning.panStart.x +
-            (panning.cursorStart.x - pointer.spaces.screen.x) / transform.zoom,
-          y:
-            panning.panStart.y +
-            (panning.cursorStart.y - pointer.spaces.screen.y) / transform.zoom,
-        },
-      }));
-      return;
-    }
-
-    if (layout.readOnly) return;
-
+  const updateDragAndLink = (diagramX, diagramY) => {
     if (linking) {
-      setLinkingLine({
-        ...linkingLine,
-        endX: pointer.spaces.diagram.x,
-        endY: pointer.spaces.diagram.y,
-      });
+      setLinkingLine((prev) => ({
+        ...prev,
+        endX: diagramX,
+        endY: diagramY,
+      }));
       return;
     }
 
     if (isDragging()) {
       const { x: mainElementFinalX, y: mainElementFinalY } =
         coordinatesAfterSnappingToGrid({
-          x: pointer.spaces.diagram.x - dragging.grabOffset.x,
-          y: pointer.spaces.diagram.y - dragging.grabOffset.y,
+          x: diagramX - dragging.grabOffset.x,
+          y: diagramY - dragging.grabOffset.y,
         });
 
-      const { currentCoords } = bulkSelectedElements.find((el) =>
+      const draggingEl = bulkSelectedElements.find((el) =>
         isSameElement(el, dragging),
       );
+      if (!draggingEl) return;
+      const { currentCoords } = draggingEl;
 
       const deltaX = mainElementFinalX - currentCoords.x;
       const deltaY = mainElementFinalY - currentCoords.y;
@@ -384,7 +362,7 @@ export default function Canvas() {
       if (areaResize.dir === "none") return;
       let newDims = { ...areaInitDimensions };
       setPanning((old) => ({ ...old, isPanning: false }));
-      const { x, y } = coordinatesAfterSnappingToGrid(pointer.spaces.diagram);
+      const { x, y } = coordinatesAfterSnappingToGrid({ x: diagramX, y: diagramY });
 
       switch (areaResize.dir) {
         case "br":
@@ -434,10 +412,38 @@ export default function Canvas() {
     if (bulkSelectRect.show) {
       setBulkSelectRect((prev) => ({
         ...prev,
-        x2: pointer.spaces.diagram.x,
-        y2: pointer.spaces.diagram.y,
+        x2: diagramX,
+        y2: diagramY,
       }));
     }
+  };
+
+  /**
+   * @param {PointerEvent} e
+   */
+  const handlePointerMove = (e) => {
+    if (selectedElement.open && !layout.sidebar) return;
+
+    if (!e.isPrimary) return;
+
+    if (panning.isPanning) {
+      setTransform((prev) => ({
+        ...prev,
+        pan: {
+          x:
+            panning.panStart.x +
+            (panning.cursorStart.x - pointer.spaces.screen.x) / transform.zoom,
+          y:
+            panning.panStart.y +
+            (panning.cursorStart.y - pointer.spaces.screen.y) / transform.zoom,
+        },
+      }));
+      return;
+    }
+
+    if (layout.readOnly) return;
+
+    updateDragAndLink(pointer.spaces.diagram.x, pointer.spaces.diagram.y);
   };
 
   /**
@@ -459,26 +465,33 @@ export default function Canvas() {
     const isMouseRightButton = e.button === 2;
 
     if (isMouseLeftButton) {
-      setBulkSelectRect({
-        x1: pointer.spaces.diagram.x,
-        y1: pointer.spaces.diagram.y,
-        x2: pointer.spaces.diagram.x,
-        y2: pointer.spaces.diagram.y,
-        show: elementPointerDown === null || !elementPointerDown.element.locked,
-        ctrlKey: e.ctrlKey,
-        metaKey: e.metaKey,
-      });
-      if (elementPointerDown !== null) {
-        handlePointerDownOnElement(e, elementPointerDown);
+      if (layout.panMode) {
+        setPanning({
+          isPanning: true,
+          panStart: transform.pan,
+          cursorStart: pointer.spaces.screen,
+        });
+        pointer.setStyle("grabbing");
+      } else {
+        setBulkSelectRect({
+          x1: pointer.spaces.diagram.x,
+          y1: pointer.spaces.diagram.y,
+          x2: pointer.spaces.diagram.x,
+          y2: pointer.spaces.diagram.y,
+          show: elementPointerDown === null || !elementPointerDown.element.locked,
+          ctrlKey: e.ctrlKey,
+          metaKey: e.metaKey,
+        });
+        if (elementPointerDown !== null) {
+          handlePointerDownOnElement(e, elementPointerDown);
+        }
+        pointer.setStyle("crosshair");
       }
-      pointer.setStyle("crosshair");
     } else if (isMouseMiddleButton || isMouseRightButton) {
       if (isMouseRightButton) rightClickPanned.current = false;
       setPanning({
         isPanning: true,
         panStart: transform.pan,
-        // Diagram space depends on the current panning.
-        // Use screen space to avoid circular dependencies and undefined behavior.
         cursorStart: pointer.spaces.screen,
       });
       pointer.setStyle("grabbing");
@@ -563,7 +576,7 @@ export default function Canvas() {
       if (e.button === 2) rightClickPanned.current = true;
     }
     setPanning((old) => ({ ...old, isPanning: false }));
-    pointer.setStyle("default");
+    pointer.setStyle(layout.panMode ? "grab" : "default");
 
     if (linking) handleLinking();
     setLinking(false);
@@ -718,6 +731,14 @@ export default function Canvas() {
     canvasRef,
     { passive: false },
   );
+
+  useEffect(() => {
+    if (layout.panMode) {
+      pointer.setStyle("grab");
+    } else {
+      pointer.setStyle("default");
+    }
+  }, [layout.panMode]);
 
   return (
     <div className="grow h-full touch-none" id="canvas">

--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -41,7 +41,7 @@ export default function Canvas() {
   const canvasRef = useRef(null);
   const canvasContextValue = useCanvas();
   const {
-    canvas: { viewBox, screenSize },
+    canvas: { viewBox },
     pointer,
   } = canvasContextValue;
 
@@ -738,7 +738,7 @@ export default function Canvas() {
     } else {
       pointer.setStyle("default");
     }
-  }, [layout.panMode]);
+  }, [layout.panMode, pointer]);
 
   return (
     <div className="grow h-full touch-none" id="canvas">

--- a/src/components/EditorCanvas/Note.jsx
+++ b/src/components/EditorCanvas/Note.jsx
@@ -256,7 +256,7 @@ export default function Note({ data, onPointerDown }) {
         strokeWidth="2"
       />
 
-      {!layout.readOnly && !data.locked && hovered && (
+      {!layout.readOnly && !data.locked && hovered && !layout.panMode && (
         <g style={{ pointerEvents: "none" }}>
           <circle
             cx={data.x}
@@ -278,7 +278,7 @@ export default function Note({ data, onPointerDown }) {
           />
         </g>
       )}
-      {!layout.readOnly && !data.locked && (
+      {!layout.readOnly && !data.locked && !layout.panMode && (
         <rect
           x={data.x - 4}
           y={data.y + 8}
@@ -338,7 +338,7 @@ export default function Note({ data, onPointerDown }) {
         />
       )}
 
-      {!layout.readOnly && !data.locked && (
+      {!layout.readOnly && !data.locked && !layout.panMode && (
         <rect
           x={data.x + width - 4}
           y={data.y + 8}
@@ -397,7 +397,7 @@ export default function Note({ data, onPointerDown }) {
         height={data.height}
         onPointerDown={onPointerDown}
       >
-        <div className="text-gray-900 select-none w-full h-full cursor-move px-3 py-2">
+        <div className={`text-gray-900 select-none w-full h-full px-3 py-2 ${layout.panMode ? "cursor-grab" : "cursor-move"}`}>
           <div className="flex justify-between gap-1 w-full">
             <label
               htmlFor={`note_${data.id}`}

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -244,7 +244,7 @@ export default function Table({
         y={tableData.y}
         width={settings.tableWidth}
         height={height}
-        className="group drop-shadow-lg rounded-md cursor-move"
+        className={`group drop-shadow-lg rounded-md ${layout.panMode ? "cursor-grab" : "cursor-move"}`}
         onPointerDown={onPointerDown}
       >
         <div
@@ -532,7 +532,7 @@ export default function Table({
             } flex items-center gap-2 overflow-hidden`}
           >
             <button
-              className="shrink-0 w-[10px] h-[10px] bg-[#2f68adcc] rounded-full"
+              className={`shrink-0 w-[10px] h-[10px] bg-[#2f68adcc] rounded-full ${layout.panMode ? "pointer-events-none opacity-50" : ""}`}
               onPointerDown={(e) => {
                 if (!e.isPrimary) return;
 

--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1835,6 +1835,9 @@ export default function ControlPanel({
   useHotkeys("mod+h", () => window.open(socials.docs, "_blank"), EDITOR_HOTKEY);
   useHotkeys("mod+alt+w", fitWindow, EDITOR_HOTKEY);
   useHotkeys("alt+e", toggleDBMLEditor, EDITOR_HOTKEY);
+  useHotkeys("h", () => setLayout((prev) => ({ ...prev, panMode: !prev.panMode })), EDITOR_HOTKEY);
+  useHotkeys("v", () => setLayout((prev) => ({ ...prev, panMode: false })), EDITOR_HOTKEY);
+  useHotkeys("escape", () => setLayout((prev) => ({ ...prev, panMode: false })), EDITOR_HOTKEY);
 
   return (
     <>
@@ -1970,6 +1973,18 @@ export default function ControlPanel({
               }
             >
               <i className="fa-solid fa-magnifying-glass-plus" />
+            </button>
+          </Tooltip>
+          <Divider layout="vertical" margin="8px" />
+          <Tooltip content={t("panning")} position="bottom">
+            <button
+              className={`py-1 px-2 hover-2 rounded-sm text-lg flex items-center ${layout.panMode ? "text-[var(--semi-color-primary)] bg-zinc-200 dark:bg-zinc-700" : ""
+                }`}
+              onClick={() =>
+                setLayout((prev) => ({ ...prev, panMode: !prev.panMode }))
+              }
+            >
+              <i className="fa-solid fa-hand" />
             </button>
           </Tooltip>
           <Divider layout="vertical" margin="8px" />

--- a/src/components/FloatingControls.jsx
+++ b/src/components/FloatingControls.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 export default function FloatingControls() {
   const { transform, setTransform } = useTransform();
-  const { setLayout } = useLayout();
+  const { layout, setLayout } = useLayout();
   const { t } = useTranslation();
 
   return (
@@ -37,6 +37,20 @@ export default function FloatingControls() {
           <i className="bi bi-plus-lg" />
         </button>
       </div>
+      <Tooltip content={t("panning")}>
+        <button
+          className={`px-3 py-2 rounded-lg popover-theme flex items-center ${layout.panMode ? "text-blue-500 bg-zinc-200 dark:bg-zinc-700" : ""
+            }`}
+          onClick={() => {
+            setLayout((prev) => ({
+              ...prev,
+              panMode: !prev.panMode,
+            }));
+          }}
+        >
+          <i className="fa-solid fa-hand text-lg" />
+        </button>
+      </Tooltip>
       <Tooltip content={t("exit")}>
         <button
           className="px-3 py-2 rounded-lg popover-theme"

--- a/src/context/LayoutContext.jsx
+++ b/src/context/LayoutContext.jsx
@@ -11,6 +11,7 @@ const defaultLayout = {
   toolbar: true,
   dbmlEditor: false,
   readOnly: false,
+  panMode: false,
 };
 
 export default function LayoutContextProvider({ children }) {


### PR DESCRIPTION
## Problem
When navigating complex database diagrams, users often accidentally select, drag, or edit elements (such as tables, notes, areas, or relationship links) while attempting to pan around the canvas.

## Solution
This PR adds a dedicated **Pan Mode** (hand tool) to the editor. When active, it shifts the canvas interaction focus purely to viewport navigation and temporarily disables element-level interactions.

### Design Decisions & Implementation
- **State Management (`LayoutContext.jsx`)**: Added `panMode: false` to `defaultLayout` so the panning state is globally accessible across all canvas components and toolbar controls while defaulting to standard select mode on load.
- **Controls & Shortcuts (`ControlPanel.jsx`, `FloatingControls.jsx`)**: Added a hand tool button to both the main toolbar and the floating controls (Zen mode). Introduced standard hotkeys: `H` to toggle pan mode, and `V` / `Esc` to return to selection mode.
- **Canvas Panning (`Canvas.jsx`)**: Pointer down/move handlers compute viewport offsets scaled by the current zoom level to maintain 1:1 cursor movement, while updating the cursor style to `grab`/`grabbing`.
- **Interaction Suppression (`Table.jsx`, `Note.jsx`, `Area.jsx`)**: Suppressed resize hitboxes and relationship-linking handles on canvas elements while `panMode` is active to prevent unintended edits.

## Testing
- Verified toggling pan mode via toolbar controls, floating controls, and keyboard shortcuts (`H`, `V`, `Esc`).
- Confirmed smooth 1:1 canvas panning at different zoom levels.
- Verified that table linking and element resizing are completely disabled while in pan mode.

Feature Demo: https://github.com/user-attachments/assets/cab875c6-07d9-49e1-b595-d9b2d1d3c8d8


Closes #1086 

