### PR TITLE
fix: GitHub stars and forks counter on landing page

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -20,20 +20,40 @@ import { Tweet } from "react-tweet";
 import { socials } from "../data/socials";
 
 function shortenNumber(number) {
+  if (typeof number !== "number" || isNaN(number)) return 0;
   if (number < 1000) return number;
 
   if (number >= 1000 && number < 1_000_000)
     return `${(number / 1000).toFixed(1)}k`;
+
+  if (number >= 1_000_000)
+    return `${(number / 1_000_000).toFixed(1)}M`;
+
+  return number;
 }
 
 export default function LandingPage() {
-  const [stats, setStats] = useState({ stars: 18000, forks: 1200 });
+  const [stats, setStats] = useState({ stars: 39000, forks: 3200 });
 
   useEffect(() => {
     const fetchStats = async () => {
-      await axios
-        .get("https://api.github-star-counter.workers.dev/user/drawdb-io")
-        .then((res) => setStats(res.data));
+      try {
+        const res = await axios.get(
+          "https://api.github.com/repos/drawdb-io/drawdb"
+        );
+        if (
+          res.data &&
+          typeof res.data.stargazers_count === "number" &&
+          typeof res.data.forks_count === "number"
+        ) {
+          setStats({
+            stars: res.data.stargazers_count,
+            forks: res.data.forks_count,
+          });
+        }
+      } catch {
+        // Ignored the fetch errors
+      }
     };
 
     document.body.setAttribute("theme-mode", "light");


### PR DESCRIPTION
## Description

Fixes an issue on the landing page where **GitHub stars** and **GitHub forks** count displayed as `0`. 

The landing page previously fetched stats from a third-party worker endpoint (`api.github-star-counter.workers.dev`), which returns `{ stars: 0, forks: 0 }` and overwrote the landing page state with zeroes.

## Solution

1. **Official GitHub REST API**: Updated `fetchStats` in `src/pages/LandingPage.jsx` to query GitHub's official repository endpoint (`https://api.github.com/repos/drawdb-io/drawdb`).
2. **Response Validation**: Added checks for `stargazers_count` and `forks_count` to ensure only valid numeric responses update the state.
3. **Silent Error Handling**: Handled network/rate-limit fetch errors silently without polluting the browser console.
4. **Updated Fallback Defaults**: Updated initial state defaults to `{ stars: 39000, forks: 3200 }` so offline / rate-limited requests render realistic counts.
5. **Formatter Improvements**: Enhanced `shortenNumber` to handle numbers $\ge 1,000,000$ and non-number edge cases safely.

## Quality & Style Check

- [x] Code adheres to the project's style guide and formatting rules.
- [x] Code passes ESLint without any warnings or errors (`npm run lint`).
- [x] Codebase remains entirely in English.
