### PR TITLE
Fix note validation on clipboard paste

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -875,7 +875,7 @@ export default function ControlPanel({
           y: obj.y + 20,
           id: areas.length,
         });
-      } else if (v.validate(obj, noteSchema)) {
+      } else if (v.validate(obj, noteSchema).valid) {
         addNote({
           ...obj,
           x: obj.x + 20,


### PR DESCRIPTION
## Summary

- check the note validation result's `valid` flag before pasting
- prevent arbitrary clipboard JSON from being passed to `addNote` and polluting diagram state

## Testing

- Ran: `npm run lint`
- Ran: `npm run build`
- Ran: `npx prettier --check src/components/EditorHeader/ControlPanel.jsx`
- Checked: deterministic `jsonschema` reproduction rejects invalid JSON while accepting valid note, table, and area objects