### PR TITLE
Fix self-referencing relationships in SQL imports

### DIFF
--- a/src/utils/importSQL/mariadb.js
+++ b/src/utils/importSQL/mariadb.js
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import { buildSQLFromAST, findReferencedTable } from "./shared";
 
 const affinity = {
   [DB.MARIADB]: new Proxy(
@@ -119,7 +119,11 @@ export function fromMariaDB(ast, diagramDb = DB.GENERIC) {
               );
               const startFieldName = startFieldNames[0];
 
-              const endTable = tables.find((t) => t.name === endTableName);
+              const endTable = findReferencedTable(
+                tables,
+                table,
+                endTableName,
+              );
               if (!endTable) return;
 
               const fieldPairs = [];

--- a/src/utils/importSQL/mysql.js
+++ b/src/utils/importSQL/mysql.js
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import { buildSQLFromAST, findReferencedTable } from "./shared";
 
 const affinity = {
   [DB.MYSQL]: new Proxy(
@@ -118,7 +118,11 @@ export function fromMySQL(ast, diagramDb = DB.GENERIC) {
               );
               const startFieldName = startFieldNames[0];
 
-              const endTable = tables.find((t) => t.name === endTableName);
+              const endTable = findReferencedTable(
+                tables,
+                table,
+                endTableName,
+              );
               if (!endTable) return;
 
               // Resolve every column pair (composite FKs carry more than one).

--- a/src/utils/importSQL/oraclesql.js
+++ b/src/utils/importSQL/oraclesql.js
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { Cardinality, Constraint, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
+import { findReferencedTable } from "./shared";
 
 const affinity = {
   [DB.ORACLESQL]: new Proxy(
@@ -105,7 +106,7 @@ export function fromOracleSQL(ast, diagramDb = DB.GENERIC) {
             const startFieldName = startFieldNames[0];
             const endTableName = d.constraint.reference.object.name;
 
-            const endTable = tables.find((t) => t.name === endTableName);
+            const endTable = findReferencedTable(tables, table, endTableName);
             if (!endTable) return;
 
             const fieldPairs = [];

--- a/src/utils/importSQL/postgres.js
+++ b/src/utils/importSQL/postgres.js
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { Cardinality, Constraint, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import { buildSQLFromAST, findReferencedTable } from "./shared";
 
 const affinity = {
   [DB.POSTGRES]: new Proxy(
@@ -139,7 +139,7 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
               );
               const startFieldName = startFieldNames[0];
 
-              const endTable = tables.find((t) => t.name === endTableName);
+              const endTable = findReferencedTable(tables, table, endTableName);
               if (!endTable) return;
 
               const fieldPairs = [];
@@ -232,7 +232,7 @@ export function fromPostgres(ast, diagramDb = DB.GENERIC) {
               }
             });
 
-            const endTable = tables.find((t) => t.name === endTableName);
+            const endTable = findReferencedTable(tables, table, endTableName);
             if (!endTable) return;
 
             const endField = endTable.fields.find(

--- a/src/utils/importSQL/shared.js
+++ b/src/utils/importSQL/shared.js
@@ -1,5 +1,11 @@
 import { DB } from "../../data/constants";
 
+export function findReferencedTable(tables, currentTable, name) {
+  return currentTable.name === name
+    ? currentTable
+    : tables.find((table) => table.name === name);
+}
+
 function quoteColumn(str, db) {
   switch (db) {
     case DB.MYSQL:

--- a/src/utils/importSQL/sqlite.js
+++ b/src/utils/importSQL/sqlite.js
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { Cardinality, DB } from "../../data/constants";
 import { dbToTypes } from "../../data/datatypes";
-import { buildSQLFromAST } from "./shared";
+import { buildSQLFromAST, findReferencedTable } from "./shared";
 
 const affinity = {
   [DB.SQLITE]: new Proxy(
@@ -51,7 +51,7 @@ export function fromSQLite(ast, diagramDb = DB.GENERIC) {
     const endFieldNames = referenceDefinition.definition.map((c) => c.column);
     const startFieldName = startFieldNames[0];
 
-    const endTable = tables.find((t) => t.name === endTableName);
+    const endTable = findReferencedTable(tables, startTable, endTableName);
     if (!endTable) return;
 
     const fieldPairs = [];


### PR DESCRIPTION
## Summary

- resolve foreign-key targets against the table currently being parsed before falling back to previously parsed tables
- preserve self-referencing relationships in MySQL, MariaDB, PostgreSQL, SQLite, and Oracle imports
- cover PostgreSQL's inline `REFERENCES` path while leaving cross-table resolution unchanged

A table is appended to the parsed table list only after its definitions are processed. As a result, a constraint such as `manager_id REFERENCES employees(id)` could not find `employees` and the relationship was silently omitted.

## Test plan

- Ran: `npm run lint`
- Ran: `npm run build`
- Checked: parser-level self-reference and cross-table reference cases for MySQL, MariaDB, PostgreSQL, SQLite, and Oracle