### PR TITLE
Fix vertical alignment of relationship labels (#1045)

### DIFF
--- a/src/components/EditorCanvas/Relationship.jsx
+++ b/src/components/EditorCanvas/Relationship.jsx
@@ -116,13 +116,12 @@ export default function Relationship({ data }) {
   let labelY = 0;
 
   let labelWidth = labelRef.current?.getBBox().width ?? 0;
-  let labelHeight = labelRef.current?.getBBox().height ?? 0;
 
   const cardinalityOffset = 28;
 
   if (composite) {
     labelX = composite.labelPoint.x - (labelWidth ?? 0) / 2;
-    labelY = composite.labelPoint.y + (labelHeight ?? 0) / 2;
+    labelY = composite.labelPoint.y;
     cardinalityStartX = composite.startCardinality.x;
     cardinalityStartY = composite.startCardinality.y;
     cardinalityEndX = composite.endCardinality.x;
@@ -132,7 +131,7 @@ export default function Relationship({ data }) {
 
     const labelPoint = pathRef.current.getPointAtLength(pathLength / 2);
     labelX = labelPoint.x - (labelWidth ?? 0) / 2;
-    labelY = labelPoint.y + (labelHeight ?? 0) / 2;
+    labelY = labelPoint.y;
 
     const point1 = pathRef.current.getPointAtLength(cardinalityOffset);
     cardinalityStartX = point1.x;
@@ -209,6 +208,7 @@ export default function Relationship({ data }) {
           <text
             x={labelX}
             y={labelY}
+            dominantBaseline="middle"
             fill={settings.mode === "dark" ? "lightgrey" : "#333"}
             fontSize={labelFontSize}
             fontWeight={500}


### PR DESCRIPTION
Closes #1045.

The relationship label `<text>` had no `dominant-baseline`, so the manual `getBBox().height / 2` offset used to fake vertical centering landed in a different spot on Firefox than on Chrome.

Setting `dominantBaseline="middle"` and positioning `y` directly on the label point centers the label consistently in both browsers. Tested the math by hand; would appreciate someone confirming in Firefox since I only have Chrome here.