### PR TITLE
fix(export): emit the comma before inline foreign keys on SQLite

### DIFF
--- a/src/utils/exportSQL/generic.js
+++ b/src/utils/exportSQL/generic.js
@@ -437,9 +437,9 @@ export function jsonToSQLite(obj) {
           ? `,\n\tPRIMARY KEY(${table.fields
               .filter((f) => f.primary)
               .map((f) => `"${f.name}"`)
-              .join(", ")})${inlineFK !== "" ? ",\n" : ""}`
+              .join(", ")})`
           : ""
-      }${inlineFK}${uniqueConstraintClause(table, (s) => `"${s}"`)}\n);\n${table.indices
+      }${inlineFK !== "" ? ",\n" : ""}${inlineFK}${uniqueConstraintClause(table, (s) => `"${s}"`)}\n);\n${table.indices
         .map(
           (i) =>
             `\nCREATE ${i.unique ? "UNIQUE " : ""}INDEX IF NOT EXISTS "${

--- a/src/utils/exportSQL/sqlite.js
+++ b/src/utils/exportSQL/sqlite.js
@@ -32,9 +32,9 @@ export function toSqlite(diagram) {
           ? `,\n\tPRIMARY KEY(${table.fields
               .filter((f) => f.primary)
               .map((f) => `"${f.name}"`)
-              .join(", ")})${inlineFK !== "" ? ",\n" : ""}`
+              .join(", ")})`
           : ""
-      }${inlineFK}${uniqueConstraintClause(table, (s) => `"${s}"`)}\n);\n${table.indices
+      }${inlineFK !== "" ? ",\n" : ""}${inlineFK}${uniqueConstraintClause(table, (s) => `"${s}"`)}\n);\n${table.indices
         .map(
           (i) =>
             `\nCREATE ${i.unique ? "UNIQUE " : ""}INDEX IF NOT EXISTS "${


### PR DESCRIPTION
## Defect

A SQLite table that has a foreign key but **no primary key** exports as invalid SQL.

Repro — `post.author_id` references `author.id`, and `post` has no primary key:

```sql
CREATE TABLE IF NOT EXISTS "post" (
	"author_id" INTEGER	FOREIGN KEY ("author_id") REFERENCES "author"("id")
	ON UPDATE NO ACTION ON DELETE NO ACTION
);
```

`sqlite3` rejects it:

```
near "FOREIGN": syntax error
```

## Cause

The separator that precedes the inline `FOREIGN KEY` block is nested **inside** the primary-key branch:

```js
table.fields.filter((f) => f.primary).length > 0
  ? `,\n\tPRIMARY KEY(...)${inlineFK !== "" ? ",\n" : ""}`
  : ""                                    // ← no primary key: no separator, even when inlineFK is non-empty
}${inlineFK}
```

So the `,\n` is only emitted when the table happens to have a primary key. With a primary key the output is correct, which is why this isn't more visible — but a foreign key on a table without a declared primary key is ordinary: a join table, or any child row keyed by something other than a PK.

## Fix

Move the separator out of the primary-key branch and key it on the foreign-key block itself:

```js
}${inlineFK !== "" ? ",\n" : ""}${inlineFK}
```

Both SQLite export paths had the same construct, so both are fixed:

- `src/utils/exportSQL/sqlite.js` — `toSqlite`
- `src/utils/exportSQL/generic.js` — `jsonToSQLite`

Other dialects are unaffected: MySQL, MariaDB, Postgres, MSSQL and Oracle emit foreign keys as separate `ALTER TABLE` statements rather than inline.

## Verification

There's no test harness in the repo, so I drove the real export functions directly and fed the output to an actual SQLite engine (`bun:sqlite`):

| | before | after |
| --- | --- | --- |
| FK, no PK | `near "FOREIGN": syntax error` | accepted |
| FK + PK (control) | accepted | accepted, byte-identical output |

Verified on both `toSqlite` and `jsonToSQLite`. Output for tables that do have a primary key is unchanged.

`npx eslint` clean on both changed files.
